### PR TITLE
Remove ability to switch users

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -26,13 +26,6 @@
           @alignment="right"
           role="menu"
         >
-          <AuLink
-            @route="auth.switch"
-            @icon="switch"
-            role="menuitem"
-          >
-            Wissel van bestuurseenheid
-          </AuLink>
 
           <AuLink
             @route="auth.logout"


### PR DESCRIPTION
LPDC is now a separate application that is opened from the main Loket app; this means however that switching between organizations (if you have the ability to do so) will not work as expected. In order for a user to switch organizations on the separate LPDC app, they would have to first go to Loket, switch organizations and open the separate LPDC application again.

Although the code change is small, this PR serves as future reference in case a working solution arrives, and the switch feature needs to be restored.