### PR TITLE
[LPDC-1270, LPDC-1276] Fix inconsistent rich text editor behavior

### DIFF
--- a/app/components/rdf-form-fields/rich-text-editor.hbs
+++ b/app/components/rdf-form-fields/rich-text-editor.hbs
@@ -11,7 +11,7 @@
     @visible={{not @show}}
     @originalStoreOptions={{this.storeOptions}}
     @field={{@field}}
-    @updateValues={{this.updateValueInStore}}
+    @updateValues={{this.handleThreeWayCompareUpdate}}
   />
 </div>
 

--- a/app/components/rdf-form-fields/rich-text-editor.js
+++ b/app/components/rdf-form-fields/rich-text-editor.js
@@ -97,7 +97,7 @@ export default class RdfFormFieldsRichTextEditorComponent extends SimpleInputFie
   @action
   handleRdfaEditorInit(editorController) {
     this.editorController = editorController;
-    this.setInitialValue();
+    this.setEditorValue();
   }
 
   @action
@@ -116,16 +116,16 @@ export default class RdfFormFieldsRichTextEditorComponent extends SimpleInputFie
       // Only trigger an update if the value actually changed.
       // This prevents that the form observer is triggered even though no editor content was changed.
       if (this.value !== editorValue) {
-        this.updateValueInStore([editorValue]);
+        this.updateValueInStore(editorValue);
       }
     }
   }
 
   @action
-  updateValueInStore(values) {
-    this.value = values[0] || '';
-    super.updateValue(this.value);
-    this.setInitialValue();
+  handleThreeWayCompareUpdate(values) {
+    const value = values[0] || '';
+    this.updateValueInStore(value);
+    this.setEditorValue();
   }
 
   loadProvidedValue() {
@@ -137,7 +137,12 @@ export default class RdfFormFieldsRichTextEditorComponent extends SimpleInputFie
     }
   }
 
-  setInitialValue() {
+  updateValueInStore(value = '') {
+    this.value = value;
+    super.updateValue(this.value);
+  }
+
+  setEditorValue() {
     if (this.value !== undefined && this.value !== null) {
       // We replicate the behavior of the controller.setHtmlContent method without focussing the field.
       // Since we use the `focusout` event focusing the field would trigger the `updateValue` action,

--- a/app/components/three-way-compare-link.hbs
+++ b/app/components/three-way-compare-link.hbs
@@ -1,14 +1,14 @@
 {{#if this.visible }}
-  <AuLink
+  <AuButton
+    @skin="link"
     class="au-u-margin-tiny"
     {{on "click" this.openModal}}>
     {{#if this.isConceptTakenOver}}
       <AuIcon
-        @alignment="right"
         @size="large"
         @icon="check">
       </AuIcon>
     {{/if}}
     Conceptwijzigingen overnemen
-  </AuLink>
+  </AuButton>
 {{/if}}


### PR DESCRIPTION
The three-way-compare feature [accidentally changed the behavior of the rich-text editor](https://github.com/lblod/frontend-lpdc/commit/208014fbaa6e95d4640d202b1b572c46dc8557b6#diff-d60f7365f9efcf3d0278aa9e5469ef334d031f0888eb339559523c5ac1291e0bR124-R128). It was updating the editor value on every change of the editor itself, but the method to update value the editor also moves the cursor around, which causes the inconsistent behavior users are seeing.

We now only update the editor value when the component is first displayed, or when the user chooses one of the 3-way compare options.

**To test**

- Create lists and links in the rich-text editor fields and see if they work as expected.
- This slighly modifies the "three-way compare" feature, so we need to check if that still works, but I don't think we can easily do that ourselves without access to IPDC. We should probably just let the test team verify this once deployed. I know there is some sort of automated testing for this project, but I'm not sure if this feature is covered by it.
