### PR TITLE
[LPDC-1276] Fix a "three-way-compare" link styling issue

### DIFF
--- a/app/components/three-way-compare-link.hbs
+++ b/app/components/three-way-compare-link.hbs
@@ -1,14 +1,10 @@
-{{#if this.visible }}
-  <AuButton
-    @skin="link"
-    class="au-u-margin-tiny"
-    {{on "click" this.openModal}}>
+{{#if this.visible}}
+  {{! We're using a link here because buttons (styled as links) have styling conflicts with the CSS hacks we use to layout the forms.
+  TODO: Replace this with an AuButton once the CSS layouting hacks are removed }}
+  <a href="#" class="au-c-link au-u-margin-tiny" {{on "click" this.openModal}}>
     {{#if this.isConceptTakenOver}}
-      <AuIcon
-        @size="large"
-        @icon="check">
-      </AuIcon>
+      <AuIcon @size="large" @icon="check" />
     {{/if}}
     Conceptwijzigingen overnemen
-  </AuButton>
+  </a>
 {{/if}}


### PR DESCRIPTION
In a previous commit we replaced the `AuLink` with a `AuButton` since that's semantically correct element to use for this scenario. However, this causes styling conflicts with the CSS hacks the project uses to style the delete buttons in the form.

So we revert back to a link, but with a regular `<a>` element and with a comment explaining the situation.

This fixes a regression introduced in #13 