### PR TITLE
feature: introduce fusies feature flag to show/hide fusies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,31 @@ LPDC Frontend is part of [LPDC - Digitaal loket](https://github.com/lblod/app-lp
 LPDC frontend is the frontend component.
 It is written in ember-js.
 
+### Environment variables
+
+The [ember-proxy-service](https://github.com/mu-semtech/ember-proxy-service#configure-environment-variables-in-the-frontends-container) docker image (which we use to host the frontend) supports configuring environment variables. The following options are available for the loket image.
+
+#### General
+
+| Name              | Description                   |
+| ----------------- | ----------------------------- |
+| `EMBER_FUSIES`    | Toggle fusies                 |
+| `EMBER_IPDC_URL`  | Link to the IPDC application  |
+| `EMBER_LOKET_URL` | Link to the Loket application |
+
+#### ACM/IDM
+
+| Name                               | Description                                                                                                                                              |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EMBER_ACMIDM_CLIENT_ID`           | The unique client id for a specific environment                                                                                                          |
+| `EMBER_ACMIDM_AUTH_URL`            | The URL where users will be redirected to when they want to log in                                                                                       |
+| `EMBER_ACMIDM_AUTH_REDIRECT_URL`   | The callback URL that ACM/IDM will use after the user logs in successfully                                                                               |
+| `EMBER_ACMIDM_LOGOUT_URL`          | The URL where users will be redirected to when they want to log out                                                                                      |
+| `EMBER_ACMIDM_SWITCH_REDIRECT_URL` | The URL that will be used when "switching users" is enabled in ACM/IDM. After logout, users can select one of their other accounts to simplify the flow. |
+
+> When ACM/IDM is not configured, the frontend will default to the "mock login" setup instead.
+>
+
 ## 2. Functional Overview
 
 ## 3. Quality Attributes

--- a/app/components/details-page.js
+++ b/app/components/details-page.js
@@ -21,6 +21,7 @@ import ENV from 'frontend-lpdc/config/environment';
 import { isConceptUpdated } from 'frontend-lpdc/models/public-service';
 import FullyTakeConceptSnapshotOverModalComponent from 'frontend-lpdc/components/fully-take-concept-snapshot-over';
 import ConfirmConvertToInformalModalComponent from 'frontend-lpdc/components/confirm-convert-to-informal-modal';
+import isFeatureEnabled from 'frontend-lpdc/helpers/is-feature-enabled';
 
 const FORM_GRAPHS = {
   formGraph: new NamedNode('http://data.lblod.info/form'),
@@ -310,26 +311,41 @@ export default class DetailsPageComponent extends Component {
 
   @action
   async copyPublicService() {
-    await this.withinUnsavedChangesModal(() => {
-      this.modals.open(ConfirmCopyModal, {
-        copyHandler: async (forMunicipalityMerger) => {
-          const copiedPublicServiceUuid =
-            await this.publicServiceService.copyPublicService(
-              this.args.publicService,
-              forMunicipalityMerger
+    if (isFeatureEnabled('fusies')) {
+      await this.withinUnsavedChangesModal(() => {
+        this.modals.open(ConfirmCopyModal, {
+          copyHandler: async (forMunicipalityMerger) => {
+            const copiedPublicServiceUuid =
+              await this.publicServiceService.copyPublicService(
+                this.args.publicService,
+                forMunicipalityMerger
+              );
+            this.toaster.success(
+              'kopiëren gelukt',
+              'Je kan nu de kopie bewerken.',
+              { timeOut: 10000 }
             );
-          this.toaster.success(
-            'kopiëren gelukt',
-            'Je kan nu de kopie bewerken.',
-            { timeOut: 10000 }
-          );
-          this.router.transitionTo(
-            'public-services.details',
-            copiedPublicServiceUuid
-          );
-        },
+            this.router.transitionTo(
+              'public-services.details',
+              copiedPublicServiceUuid
+            );
+          },
+        });
       });
-    });
+    } else {
+      const copiedPublicServiceUuid =
+        await this.publicServiceService.copyPublicService(
+          this.args.publicService,
+          false
+        );
+      this.toaster.success('kopiëren gelukt', 'Je kan nu de kopie bewerken.', {
+        timeOut: 10000,
+      });
+      this.router.transitionTo(
+        'public-services.details',
+        copiedPublicServiceUuid
+      );
+    }
   }
 
   @action

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -29,7 +29,7 @@
           @onChange={{this.handleYourEuropeFilterChange}}>
           Your Europe
         </AuCheckbox>
-        {{#if this.municipalityHasForMunicipalityMergerInstances}}
+        {{#if (and (is-feature-enabled "fusies") this.municipalityHasForMunicipalityMergerInstances)}}
           <AuCheckbox
             @checked={{this.forMunicipalityMerger}}
             @onChange={{this.handleForMunicipalityMergerFilterChange}}>
@@ -181,7 +181,7 @@
               >
                 {{publicService.nameNlOrGeenTitel}}
               </AuLink>
-              {{#if publicService.forMunicipalityMerger}}
+              {{#if (and (is-feature-enabled "fusies") publicService.forMunicipalityMerger)}}
                 <AuPill @skin="success" @size="small" @icon="users-four-of-four">
                   fusie
                 </AuPill>

--- a/config/environment.js
+++ b/config/environment.js
@@ -33,7 +33,7 @@ module.exports = function (environment) {
     },
     features: {
       // 'feature-name': '{{FEATURE_ENV_VAR_NAME}}',
-      fusies: false,
+      fusies: '{{FUSIES}}',
     },
     'ember-plausible': {
       enabled: false,

--- a/config/environment.js
+++ b/config/environment.js
@@ -31,9 +31,10 @@ module.exports = function (environment) {
       authRedirectUrl: '{{ACMIDM_AUTH_REDIRECT_URL}}',
       switchRedirectUrl: '{{ACMIDM_SWITCH_REDIRECT_URL}}',
     },
-    // features: {
-    //   'feature-name': '{{FEATURE_ENV_VAR_NAME}}',
-    // },
+    features: {
+      // 'feature-name': '{{FEATURE_ENV_VAR_NAME}}',
+      fusies: false,
+    },
     'ember-plausible': {
       enabled: false,
     },


### PR DESCRIPTION
## ID 

LPDC-1339

## Description

Fusies will no longer be needed (for now), but will be in the future. Which is why this PR uses a feature flag to show / hide code about the fusies:

- 'Sorteren en filteren': the fusies filter should not be showing anymore
- The fusies pill in the table should not be showing anymore
- The copy button should now directly copy, and not open a popup to choose between fusie and regular

Note: the fusie-toggle when creating a new fusie is part of a different [PR](https://github.com/lblod/lpdc-management-service/pull/54)
