### PR TITLE
fix: show error messages before asking for confirmation to publish product instance

### DIFF
--- a/app/components/details-page.js
+++ b/app/components/details-page.js
@@ -115,10 +115,10 @@ export default class DetailsPageComponent extends Component {
         : 'nl';
 
     const latestSnapshot = getUUIDFromUri(
-      this.args.publicService.concept.get('hasLatestFunctionalChange'),
+      this.args.publicService.concept.get('hasLatestFunctionalChange')
     );
     const publicServiceSnapshot = getUUIDFromUri(
-      this.args.publicService.versionedSource,
+      this.args.publicService.versionedSource
     );
     return `${ENV.ipdcUrl}/${languageVersion}/concept/${productId}/revisie/vergelijk?revisie1=${publicServiceSnapshot}&revisie2=${latestSnapshot}`;
   }
@@ -158,7 +158,7 @@ export default class DetailsPageComponent extends Component {
       source: sourceTtl,
     } = yield this.publicServiceService.getPublicServiceForm(
       this.args.publicService,
-      this.args.formId,
+      this.args.formId
     );
 
     let formStore = new ForkingStore();
@@ -170,7 +170,7 @@ export default class DetailsPageComponent extends Component {
       undefined,
       RDF('type'),
       FORM('Form'),
-      FORM_GRAPHS.formGraph,
+      FORM_GRAPHS.formGraph
     );
 
     if (!this.args.readOnly) {
@@ -217,7 +217,7 @@ export default class DetailsPageComponent extends Component {
       yield this.modals.open(ConfirmUpToDateTillModal, {
         confirmUpToDateTillHandler: async () => {
           await this.publicServiceService.confirmUpToDateTillLatestFunctionalChange(
-            this.args.publicService,
+            this.args.publicService
           );
         },
       });
@@ -229,14 +229,14 @@ export default class DetailsPageComponent extends Component {
     let { publicService } = this.args;
     let serializedData = this.formStore.serializeDataWithAddAndDelGraph(
       this.graphs.sourceGraph,
-      'application/n-triples',
+      'application/n-triples'
     );
 
     // Validate and inform user if any warnings arise
     const errors =
       yield this.publicServiceService.validatePublicServiceBeforeUpdate(
         publicService,
-        serializedData,
+        serializedData
       );
 
     if (errors.length > 0) {
@@ -248,10 +248,10 @@ export default class DetailsPageComponent extends Component {
       this.hasValidationErrors = false;
       yield this.publicServiceService.updatePublicService(
         publicService,
-        serializedData,
+        serializedData
       );
       yield this.publicServiceService.loadPublicServiceDetails(
-        publicService.id,
+        publicService.id
       );
       yield this.loadForm.perform();
     }
@@ -282,7 +282,7 @@ export default class DetailsPageComponent extends Component {
       // currently open form contains an error. One message from the `else`
       // block below and one from `validateInstance`.
       const publishErrors = yield this.publicServiceService.validateInstance(
-        this.args.publicService,
+        this.args.publicService
       );
 
       if (publishErrors.length === 0) {
@@ -290,7 +290,7 @@ export default class DetailsPageComponent extends Component {
           yield this.modals.open(ConfirmUpToDateTillModal, {
             confirmUpToDateTillHandler: async () => {
               await this.publicServiceService.confirmUpToDateTillLatestFunctionalChange(
-                this.args.publicService,
+                this.args.publicService
               );
             },
           });
@@ -303,7 +303,7 @@ export default class DetailsPageComponent extends Component {
         });
       } else {
         publishErrors.forEach((error) =>
-          this.#showToasterErrorMessage(error.message),
+          this.#showToasterErrorMessage(error.message)
         );
       }
     } else {
@@ -315,7 +315,7 @@ export default class DetailsPageComponent extends Component {
   *confirmInstanceAlreadyInformal() {
     const { publicService } = this.args;
     yield this.publicServiceService.confirmInstanceAlreadyInformal(
-      publicService,
+      publicService
     );
   }
 
@@ -336,7 +336,7 @@ export default class DetailsPageComponent extends Component {
     this.modals.open(ConfirmDeletionModal, {
       deleteHandler: async () => {
         await this.publicServiceService.deletePublicService(
-          this.args.publicService.uri,
+          this.args.publicService.uri
         );
         this.updateHasUnsavedChanges(false);
         this.router.replaceWith('public-services');
@@ -353,16 +353,16 @@ export default class DetailsPageComponent extends Component {
             const copiedPublicServiceUuid =
               await this.publicServiceService.copyPublicService(
                 this.args.publicService,
-                forMunicipalityMerger,
+                forMunicipalityMerger
               );
             this.toaster.success(
               'kopiëren gelukt',
               'Je kan nu de kopie bewerken.',
-              { timeOut: 10000 },
+              { timeOut: 10000 }
             );
             this.router.transitionTo(
               'public-services.details',
-              copiedPublicServiceUuid,
+              copiedPublicServiceUuid
             );
           },
         });
@@ -371,14 +371,14 @@ export default class DetailsPageComponent extends Component {
       const copiedPublicServiceUuid =
         await this.publicServiceService.copyPublicService(
           this.args.publicService,
-          false,
+          false
         );
       this.toaster.success('kopiëren gelukt', 'Je kan nu de kopie bewerken.', {
         timeOut: 10000,
       });
       this.router.transitionTo(
         'public-services.details',
-        copiedPublicServiceUuid,
+        copiedPublicServiceUuid
       );
     }
   }
@@ -390,7 +390,7 @@ export default class DetailsPageComponent extends Component {
         fullyTakeConceptSnapshotOverHandler: async () => {
           let { publicService } = this.args;
           await this.publicServiceService.fullyTakeConceptSnapshotOver(
-            publicService,
+            publicService
           );
           this.router.refresh('public-services.details');
         },
@@ -411,7 +411,7 @@ export default class DetailsPageComponent extends Component {
       convertToInformalHandler: async () => {
         let { publicService } = this.args;
         await this.publicServiceService.convertInstanceToInformal(
-          publicService,
+          publicService
         );
         this.router.refresh('public-services.details');
       },
@@ -422,7 +422,7 @@ export default class DetailsPageComponent extends Component {
   *markAsReviewed() {
     let { publicService } = this.args;
     yield this.publicServiceService.confirmUpToDateTillLatestFunctionalChange(
-      publicService,
+      publicService
     );
   }
 
@@ -440,14 +440,14 @@ export default class DetailsPageComponent extends Component {
           saveHandler: async () => {
             await this.saveSemanticForm.perform();
           },
-        },
+        }
       );
 
       if (this.args.publicService.reviewStatus && saved) {
         await this.modals.open(ConfirmUpToDateTillModal, {
           confirmUpToDateTillHandler: async () => {
             await this.publicServiceService.confirmUpToDateTillLatestFunctionalChange(
-              this.args.publicService,
+              this.args.publicService
             );
           },
         });
@@ -468,14 +468,14 @@ export default class DetailsPageComponent extends Component {
           saveHandler: async () => {
             await this.saveSemanticForm.perform();
           },
-        },
+        }
       );
 
       if (shouldTransition) {
         if (!saved) {
           let { publicService } = this.args;
           await this.publicServiceService.loadPublicServiceDetails(
-            publicService.id,
+            publicService.id
           );
           await this.loadForm.perform();
         }

--- a/app/components/details-page.js
+++ b/app/components/details-page.js
@@ -195,19 +195,13 @@ export default class DetailsPageComponent extends Component {
 
   @task({ group: 'publicServiceAction' })
   *publishPublicService() {
+    // NOTE (10/04/2025): Before calling this the `publicService` should have
+    // been validated using `this.publicServiceService.validateInstance`,
+    // otherwise incorrect product instances can be published.
     const { publicService } = this.args;
-    const validationErrors =
-      yield this.publicServiceService.validateInstance(publicService);
+    yield this.publicServiceService.publishInstance(publicService);
 
-    if (validationErrors.length > 0) {
-      for (const validationError of validationErrors) {
-        this.toaster.error(validationError.message, 'Fout', { timeOut: 30000 });
-      }
-    } else {
-      yield this.publicServiceService.publishInstance(publicService);
-
-      this.router.transitionTo('public-services');
-    }
+    this.router.transitionTo('public-services');
   }
 
   @task({ group: 'publicServiceAction' })

--- a/app/components/details-page.js
+++ b/app/components/details-page.js
@@ -56,6 +56,10 @@ export default class DetailsPageComponent extends Component {
     }
   }
 
+  #showToasterErrorMessage(message) {
+    this.toaster.error(message, 'Fout', { timeOut: 30000 });
+  }
+
   get isStatusVerzondenAndPublished() {
     return this.args.isPublished && this.args.publicService.isSent;
   }
@@ -238,7 +242,7 @@ export default class DetailsPageComponent extends Component {
     if (errors.length > 0) {
       this.hasValidationErrors = true;
       for (const error of errors) {
-        this.toaster.error(error.message, 'Fout', { timeOut: 30000 });
+        this.#showToasterErrorMessage(error.message);
       }
     } else {
       this.hasValidationErrors = false;
@@ -298,14 +302,12 @@ export default class DetailsPageComponent extends Component {
           },
         });
       } else {
-        publishErrors.forEach(
-          (error) => this.toaster.error(error.message),
-          'Fout',
-          { timeOut: 3000 },
+        publishErrors.forEach((error) =>
+          this.#showToasterErrorMessage(error.message),
         );
       }
     } else {
-      this.toaster.error('Formulier is ongeldig', 'Fout', { timeOut: 30000 });
+      this.#showToasterErrorMessage('Formulier is ongeldig');
     }
   }
 

--- a/app/components/details-page.js
+++ b/app/components/details-page.js
@@ -111,10 +111,10 @@ export default class DetailsPageComponent extends Component {
         : 'nl';
 
     const latestSnapshot = getUUIDFromUri(
-      this.args.publicService.concept.get('hasLatestFunctionalChange')
+      this.args.publicService.concept.get('hasLatestFunctionalChange'),
     );
     const publicServiceSnapshot = getUUIDFromUri(
-      this.args.publicService.versionedSource
+      this.args.publicService.versionedSource,
     );
     return `${ENV.ipdcUrl}/${languageVersion}/concept/${productId}/revisie/vergelijk?revisie1=${publicServiceSnapshot}&revisie2=${latestSnapshot}`;
   }
@@ -154,7 +154,7 @@ export default class DetailsPageComponent extends Component {
       source: sourceTtl,
     } = yield this.publicServiceService.getPublicServiceForm(
       this.args.publicService,
-      this.args.formId
+      this.args.formId,
     );
 
     let formStore = new ForkingStore();
@@ -166,7 +166,7 @@ export default class DetailsPageComponent extends Component {
       undefined,
       RDF('type'),
       FORM('Form'),
-      FORM_GRAPHS.formGraph
+      FORM_GRAPHS.formGraph,
     );
 
     if (!this.args.readOnly) {
@@ -196,9 +196,8 @@ export default class DetailsPageComponent extends Component {
   @task({ group: 'publicServiceAction' })
   *publishPublicService() {
     const { publicService } = this.args;
-    const validationErrors = yield this.publicServiceService.validateInstance(
-      publicService
-    );
+    const validationErrors =
+      yield this.publicServiceService.validateInstance(publicService);
 
     if (validationErrors.length > 0) {
       for (const validationError of validationErrors) {
@@ -220,7 +219,7 @@ export default class DetailsPageComponent extends Component {
       yield this.modals.open(ConfirmUpToDateTillModal, {
         confirmUpToDateTillHandler: async () => {
           await this.publicServiceService.confirmUpToDateTillLatestFunctionalChange(
-            this.args.publicService
+            this.args.publicService,
           );
         },
       });
@@ -232,14 +231,14 @@ export default class DetailsPageComponent extends Component {
     let { publicService } = this.args;
     let serializedData = this.formStore.serializeDataWithAddAndDelGraph(
       this.graphs.sourceGraph,
-      'application/n-triples'
+      'application/n-triples',
     );
 
     // Validate and inform user if any warnings arise
     const errors =
       yield this.publicServiceService.validatePublicServiceBeforeUpdate(
         publicService,
-        serializedData
+        serializedData,
       );
 
     if (errors.length > 0) {
@@ -251,10 +250,10 @@ export default class DetailsPageComponent extends Component {
       this.hasValidationErrors = false;
       yield this.publicServiceService.updatePublicService(
         publicService,
-        serializedData
+        serializedData,
       );
       yield this.publicServiceService.loadPublicServiceDetails(
-        publicService.id
+        publicService.id,
       );
       yield this.loadForm.perform();
     }
@@ -284,7 +283,7 @@ export default class DetailsPageComponent extends Component {
         yield this.modals.open(ConfirmUpToDateTillModal, {
           confirmUpToDateTillHandler: async () => {
             await this.publicServiceService.confirmUpToDateTillLatestFunctionalChange(
-              this.args.publicService
+              this.args.publicService,
             );
           },
         });
@@ -304,7 +303,7 @@ export default class DetailsPageComponent extends Component {
   *confirmInstanceAlreadyInformal() {
     const { publicService } = this.args;
     yield this.publicServiceService.confirmInstanceAlreadyInformal(
-      publicService
+      publicService,
     );
   }
 
@@ -325,7 +324,7 @@ export default class DetailsPageComponent extends Component {
     this.modals.open(ConfirmDeletionModal, {
       deleteHandler: async () => {
         await this.publicServiceService.deletePublicService(
-          this.args.publicService.uri
+          this.args.publicService.uri,
         );
         this.updateHasUnsavedChanges(false);
         this.router.replaceWith('public-services');
@@ -342,16 +341,16 @@ export default class DetailsPageComponent extends Component {
             const copiedPublicServiceUuid =
               await this.publicServiceService.copyPublicService(
                 this.args.publicService,
-                forMunicipalityMerger
+                forMunicipalityMerger,
               );
             this.toaster.success(
               'kopiëren gelukt',
               'Je kan nu de kopie bewerken.',
-              { timeOut: 10000 }
+              { timeOut: 10000 },
             );
             this.router.transitionTo(
               'public-services.details',
-              copiedPublicServiceUuid
+              copiedPublicServiceUuid,
             );
           },
         });
@@ -360,14 +359,14 @@ export default class DetailsPageComponent extends Component {
       const copiedPublicServiceUuid =
         await this.publicServiceService.copyPublicService(
           this.args.publicService,
-          false
+          false,
         );
       this.toaster.success('kopiëren gelukt', 'Je kan nu de kopie bewerken.', {
         timeOut: 10000,
       });
       this.router.transitionTo(
         'public-services.details',
-        copiedPublicServiceUuid
+        copiedPublicServiceUuid,
       );
     }
   }
@@ -379,7 +378,7 @@ export default class DetailsPageComponent extends Component {
         fullyTakeConceptSnapshotOverHandler: async () => {
           let { publicService } = this.args;
           await this.publicServiceService.fullyTakeConceptSnapshotOver(
-            publicService
+            publicService,
           );
           this.router.refresh('public-services.details');
         },
@@ -400,7 +399,7 @@ export default class DetailsPageComponent extends Component {
       convertToInformalHandler: async () => {
         let { publicService } = this.args;
         await this.publicServiceService.convertInstanceToInformal(
-          publicService
+          publicService,
         );
         this.router.refresh('public-services.details');
       },
@@ -411,7 +410,7 @@ export default class DetailsPageComponent extends Component {
   *markAsReviewed() {
     let { publicService } = this.args;
     yield this.publicServiceService.confirmUpToDateTillLatestFunctionalChange(
-      publicService
+      publicService,
     );
   }
 
@@ -429,14 +428,14 @@ export default class DetailsPageComponent extends Component {
           saveHandler: async () => {
             await this.saveSemanticForm.perform();
           },
-        }
+        },
       );
 
       if (this.args.publicService.reviewStatus && saved) {
         await this.modals.open(ConfirmUpToDateTillModal, {
           confirmUpToDateTillHandler: async () => {
             await this.publicServiceService.confirmUpToDateTillLatestFunctionalChange(
-              this.args.publicService
+              this.args.publicService,
             );
           },
         });
@@ -457,14 +456,14 @@ export default class DetailsPageComponent extends Component {
           saveHandler: async () => {
             await this.saveSemanticForm.perform();
           },
-        }
+        },
       );
 
       if (shouldTransition) {
         if (!saved) {
           let { publicService } = this.args;
           await this.publicServiceService.loadPublicServiceDetails(
-            publicService.id
+            publicService.id,
           );
           await this.loadForm.perform();
         }


### PR DESCRIPTION
In [#50](https://github.com/lblod/lpdc-management-service/pull/50) and [#51](https://github.com/lblod/lpdc-management-service/pull/51) the `management` service was extended with extra validations to prevent 'faulty' product instances from being published to IPDC. In summary, product instances that refer to inactive competent/executing authorities or expires spatials can no longer be published.

At the time the frontend was not adapted. This leads to a situation were users are first asked to confirm whether they really want to publish a product instance only to be presented with error messages after confirming. This PR switches this order. Now any validation errors will be shown first and the publish confirmation modal is only shown when there are no (more) errors.

## How to reproduce the bug
0. Launch a local version of (the) LPDC (frontend)
1. Log in, any organisation with product instances should do
2. Select a product instance
3. Edit the product instance in such a way that it will trigger the appropriate validation errors for publishing. For example, select as spatial (*nl. Geografisch toepassingsgebied*) that has expired, such as *Galmaarden*.
4. Try to publish the product instance using the "Verzend naar Vlaamse overheid" button in the top right corner.
5. The publish confirmation modal will pop up, confirm publishing via the appropriately labelled "Verzend naar Vlaamse overheid" button.
6. After confirming, an error message will appear in the top right corner.

If you launched a frontend for the branch of this PR, you should not get the modal in step 5 but immediately get the error message of step 6.