### PR TITLE
refactor: validate authority levels on publish instead of on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+#### :bug: Bug Fix
+* [#30](https://github.com/lblod/frontend-lpdc/pull/30) refactor: validate authority levels on publish instead of on save [LPDC-1431] ([@wolfderechter](https://github.com/wolfderechter))
+
 ## v0.22.1 (2025-05-28)
 #### :bug: Bug Fix
 * [#28](https://github.com/lblod/frontend-lpdc/pull/28) upgrade to 2.10.3 submission-form-helpers ([@wolfderechter](https://github.com/wolfderechter))

--- a/app/components/details-page.js
+++ b/app/components/details-page.js
@@ -232,29 +232,12 @@ export default class DetailsPageComponent extends Component {
       'application/n-triples'
     );
 
-    // Validate and inform user if any warnings arise
-    const errors =
-      yield this.publicServiceService.validatePublicServiceBeforeUpdate(
-        publicService,
-        serializedData
-      );
-
-    if (errors.length > 0) {
-      this.hasValidationErrors = true;
-      for (const error of errors) {
-        this.#showToasterErrorMessage(error.message);
-      }
-    } else {
-      this.hasValidationErrors = false;
-      yield this.publicServiceService.updatePublicService(
-        publicService,
-        serializedData
-      );
-      yield this.publicServiceService.loadPublicServiceDetails(
-        publicService.id
-      );
-      yield this.loadForm.perform();
-    }
+    yield this.publicServiceService.updatePublicService(
+      publicService,
+      serializedData
+    );
+    yield this.publicServiceService.loadPublicServiceDetails(publicService.id);
+    yield this.loadForm.perform();
   }
 
   @dropTask
@@ -269,11 +252,6 @@ export default class DetailsPageComponent extends Component {
     // Save this form first
     if (this.hasUnsavedChanges) {
       yield this.saveSemanticForm.unlinked().perform();
-    }
-
-    // If the form has validation errors, don't show the submit popup
-    if (this.hasValidationErrors) {
-      return;
     }
 
     if (isValidForm) {

--- a/app/services/public-service.js
+++ b/app/services/public-service.js
@@ -197,19 +197,6 @@ export default class PublicServiceService extends Service {
     );
   }
 
-  // Used to validate BEFORE saving/updating
-  async validatePublicServiceBeforeUpdate(publicService, formData) {
-    return await this.httpRequest.put(
-      `/lpdc-management/public-services/${encodeURIComponent(
-        publicService.uri
-      )}/validate-for-update`,
-      formData,
-      {
-        'instance-version': moment(publicService.dateModified).toISOString(),
-      }
-    );
-  }
-
   async publishInstance(publicService) {
     await this.httpRequest.put(
       `/lpdc-management/public-services/${encodeURIComponent(


### PR DESCRIPTION
## ID

LPDC-1431

## Description

Refactor to only validate the authority levels on publish instead of on save. This way the save isn't blocked and work doesn't get discarded when clicking between tabs.

## Linked PR's

- https://github.com/lblod/lpdc-management-service/pull/63