### PR TITLE
[LPDC-1668]: notifications integration

### DIFF
--- a/app/components/details-page.hbs
+++ b/app/components/details-page.hbs
@@ -88,15 +88,16 @@
         </AuTooltip>
       </AuDropdown>
     </AuButtonGroup>
-    <div class="au-u-margin-top-tiny au-u-margin-right-tiny">
-      <AuToggleSwitch
-        @checked={{this.hasNotificationEnabled}}
-        @onChange={{this.toggleReceiveNotifications}}
-      >
-        Notificaties ontvangen over deze instantie
-      </AuToggleSwitch>
-    </div>
-
+    {{#if this.notificationService.isNotificationsEnabled}}
+      <div class="au-u-margin-top-tiny au-u-margin-right-tiny">
+        <AuToggleSwitch
+          @checked={{this.hasNotificationEnabled}}
+          @onChange={{this.toggleReceiveNotifications}}
+        >
+          Notificaties ontvangen over deze instantie
+        </AuToggleSwitch>
+      </div>
+    {{/if}}
   </Group>
 </AuToolbar>
 <AuToolbar

--- a/app/components/details-page.hbs
+++ b/app/components/details-page.hbs
@@ -5,7 +5,7 @@
       {{{@publicService.nameNl}}}
     </AuHeading>
   </Group>
-  <Group>
+  <Group class="au-u-flex au-u-flex--column">
     <AuButtonGroup class="au-u-flex--no-wrap">
       {{#if @readOnly}}
         <AuButton {{on "click" this.requestReopeningConfirmation}}>
@@ -29,66 +29,75 @@
           Wijzigingen bewaren
         </AuButton>
       {{/if}}
-    </AuButtonGroup>
-
-    <AuDropdown
-      @title="Acties"
-      @skin="naked"
-      @alignment="right"
-      @icon="chevron-down"
-      @iconAlignment="right"
-      role="menu"
-    >
-      {{#if this.shouldDisplayEnLinkToIpdc}}
-        <AuLinkExternal
-          href={{this.ipdcEnLink}}
-          @skin="link"
-          @icon="eye"
-          role="menuitem"
-          target="blank"
-        >
-          Bekijk Engelse vertaling
-        </AuLinkExternal>
-      {{/if}}
-      {{#if this.shouldDisplayReadonlyEnLinkToIpdc}}
-        <AuButton
-          @icon="not-visible"
-          @skin="link"
-          role="menuitem"
-          @disabled={{true}}
-          target="blank"
-        >
-          Engelse vertaling na publicatie
-        </AuButton>
-      {{/if}}
-      <AuButton
-        @skin="link"
-        @icon="copy"
-        role="menuitem"
-        @disabled={{false}}
-        {{on "click" this.copyPublicService}}
+      <AuDropdown
+        @title="Acties"
+        @skin="naked"
+        @alignment="right"
+        @icon="chevron-down"
+        @iconAlignment="right"
+        role="menu"
       >
-        Product kopiëren
-      </AuButton>
-      <AuTooltip @placement="left" as |tooltip|>
-        {{! template-lint-disable require-context-role }}
+        {{#if this.shouldDisplayEnLinkToIpdc}}
+          <AuLinkExternal
+            href={{this.ipdcEnLink}}
+            @skin="link"
+            @icon="eye"
+            role="menuitem"
+            target="blank"
+          >
+            Bekijk Engelse vertaling
+          </AuLinkExternal>
+        {{/if}}
+        {{#if this.shouldDisplayReadonlyEnLinkToIpdc}}
+          <AuButton
+            @icon="not-visible"
+            @skin="link"
+            role="menuitem"
+            @disabled={{true}}
+            target="blank"
+          >
+            Engelse vertaling na publicatie
+          </AuButton>
+        {{/if}}
         <AuButton
           @skin="link"
-          @icon="bin"
+          @icon="copy"
           role="menuitem"
-          @alert={{true}}
-          @disabled={{this.shouldDisplayProductVerwijderenButton}}
-          {{(if this.shouldDisplayProductVerwijderenButton tooltip.target)}}
-          {{on "click" this.removePublicService}}
+          @disabled={{false}}
+          {{on "click" this.copyPublicService}}
         >
-          Product verwijderen
+          Product kopiëren
         </AuButton>
-        <tooltip.Content>
-          Klik eerst op de blauwe knop "Product opnieuw bewerken" om je
-          productfiche te verwijderen
-        </tooltip.Content>
-      </AuTooltip>
-    </AuDropdown>
+        <AuTooltip @placement="left" as |tooltip|>
+          {{! template-lint-disable require-context-role }}
+          <AuButton
+            @skin="link"
+            @icon="bin"
+            role="menuitem"
+            @alert={{true}}
+            @disabled={{this.shouldDisplayProductVerwijderenButton}}
+            {{(if this.shouldDisplayProductVerwijderenButton tooltip.target)}}
+            {{on "click" this.removePublicService}}
+          >
+            Product verwijderen
+          </AuButton>
+          <tooltip.Content>
+            Klik eerst op de blauwe knop "Product opnieuw bewerken" om je
+            productfiche te verwijderen
+          </tooltip.Content>
+        </AuTooltip>
+      </AuDropdown>
+    </AuButtonGroup>
+    {{!-- template-lint-disable no-inline-styles --}}
+    <div class="au-u-margin-top-tiny au-u-margin-right-tiny" style="margin-left: auto;">
+      <AuToggleSwitch
+        @checked={{this.hasNotificationEnabled}}
+        @onChange={{this.toggleReceiveNotifications}}
+      >
+        Notificaties ontvangen over deze instantie
+      </AuToggleSwitch>
+    </div>
+
   </Group>
 </AuToolbar>
 <AuToolbar

--- a/app/components/details-page.hbs
+++ b/app/components/details-page.hbs
@@ -5,7 +5,7 @@
       {{{@publicService.nameNl}}}
     </AuHeading>
   </Group>
-  <Group class="au-u-flex au-u-flex--column">
+  <Group class="au-u-flex au-u-flex--column au-u-flex--vertical-end">
     <AuButtonGroup class="au-u-flex--no-wrap">
       {{#if @readOnly}}
         <AuButton {{on "click" this.requestReopeningConfirmation}}>
@@ -88,8 +88,7 @@
         </AuTooltip>
       </AuDropdown>
     </AuButtonGroup>
-    {{!-- template-lint-disable no-inline-styles --}}
-    <div class="au-u-margin-top-tiny au-u-margin-right-tiny" style="margin-left: auto;">
+    <div class="au-u-margin-top-tiny au-u-margin-right-tiny">
       <AuToggleSwitch
         @checked={{this.hasNotificationEnabled}}
         @onChange={{this.toggleReceiveNotifications}}

--- a/app/components/details-page.js
+++ b/app/components/details-page.js
@@ -36,6 +36,7 @@ export default class DetailsPageComponent extends Component {
   @service store;
   @service toaster;
   @service('public-service') publicServiceService;
+  @service('notification') notificationService;
   @service contextService;
 
   @tracked hasValidationErrors = false;
@@ -45,6 +46,7 @@ export default class DetailsPageComponent extends Component {
   @tracked includeFeedbackHistory = true;
   @tracked feedbackSidebarExpanded = this.feedbackAvailable;
   @tracked hasFeedback = this.feedbackAvailable;
+  @tracked hasNotificationEnabled = false;
   id = guidFor(this);
   @tracked formStore;
   graphs = FORM_GRAPHS;
@@ -53,6 +55,7 @@ export default class DetailsPageComponent extends Component {
     super(...arguments);
     this.loadForm.perform();
     this.loadFeedback.perform();
+    this.loadNotificationEnabled();
     this.sourceNode = new NamedNode(this.args.publicService.uri);
 
     if (!this.args.readOnly) {
@@ -225,6 +228,33 @@ export default class DetailsPageComponent extends Component {
       );
     });
   });
+
+  async loadNotificationEnabled() {
+    const preference =
+      await this.notificationService.getNotificationPreference();
+    if (preference) {
+      const instances = await preference.instances;
+      this.hasNotificationEnabled = instances
+        .map((i) => i.id)
+        .includes(this.args.publicService.id);
+    }
+  }
+
+  @action
+  async toggleReceiveNotifications(isChecked) {
+    const preference =
+      await this.notificationService.getNotificationPreference();
+    const instances = await preference.instances;
+
+    if (isChecked) {
+      preference.instances = [...instances, this.args.publicService];
+    } else {
+      preference.instances = instances.filter(
+        (instance) => instance !== this.args.publicService,
+      );
+    }
+    await preference.save();
+  }
 
   @action
   updateFormDirtyState(/* delta */) {

--- a/app/components/details-page.js
+++ b/app/components/details-page.js
@@ -244,16 +244,18 @@ export default class DetailsPageComponent extends Component {
   async toggleReceiveNotifications(isChecked) {
     const preference =
       await this.notificationService.getNotificationPreference();
-    const instances = await preference.instances;
+    if (preference) {
+      const instances = await preference.instances;
 
-    if (isChecked) {
-      preference.instances = [...instances, this.args.publicService];
-    } else {
-      preference.instances = instances.filter(
-        (instance) => instance !== this.args.publicService,
-      );
+      if (isChecked) {
+        preference.instances = [...instances, this.args.publicService];
+      } else {
+        preference.instances = instances.filter(
+          (instance) => instance !== this.args.publicService,
+        );
+      }
+      await preference.save();
     }
-    await preference.save();
   }
 
   @action

--- a/app/components/feedback.js
+++ b/app/components/feedback.js
@@ -110,9 +110,9 @@ export default class FeedbackComponent extends Component {
     const bestuurseenheid = results.find((b) => b.uri === answerSender.uri);
 
     if (bestuurseenheid) {
-      return `${bestuurseenheid.classificatie.label} ${bestuurseenheid.naam}`;
+      return bestuurseenheid.organizationName;
     } else {
-      return `${answerSender.label}`;
+      return answerSender.label;
     }
   }
 

--- a/app/components/feedback.js
+++ b/app/components/feedback.js
@@ -10,6 +10,7 @@ import {
   FEEDBACK_STATUS_LABELS,
   FEEDBACK_PROCESSING_STATUS_LABELS,
 } from 'frontend-lpdc/models/feedback';
+import { organizationName } from 'frontend-lpdc/helpers/organization-name';
 
 export default class FeedbackComponent extends Component {
   @service modals;
@@ -110,7 +111,7 @@ export default class FeedbackComponent extends Component {
     const bestuurseenheid = results.find((b) => b.uri === answerSender.uri);
 
     if (bestuurseenheid) {
-      return bestuurseenheid.organizationName;
+      return organizationName([bestuurseenheid]);
     } else {
       return answerSender.label;
     }

--- a/app/components/feedback.js
+++ b/app/components/feedback.js
@@ -10,7 +10,7 @@ import {
   FEEDBACK_STATUS_LABELS,
   FEEDBACK_PROCESSING_STATUS_LABELS,
 } from 'frontend-lpdc/models/feedback';
-import { organizationName } from 'frontend-lpdc/helpers/organization-name';
+import organizationName from 'frontend-lpdc/helpers/organization-name';
 
 export default class FeedbackComponent extends Component {
   @service modals;
@@ -111,7 +111,7 @@ export default class FeedbackComponent extends Component {
     const bestuurseenheid = results.find((b) => b.uri === answerSender.uri);
 
     if (bestuurseenheid) {
-      return organizationName([bestuurseenheid]);
+      return organizationName(bestuurseenheid);
     } else {
       return answerSender.label;
     }

--- a/app/components/icons/alarm.hbs
+++ b/app/components/icons/alarm.hbs
@@ -1,0 +1,6 @@
+{{! TODO: Appuniversum doesn't ship these icons yet, but they come from the official Webuniversum Figma. Remove this once all the icons are added to Appuniversum: https://github.com/appuniversum/ember-appuniversum/issues/482 }}
+<svg ...attributes xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M11 2H13V4.08329C15.8345 4.56058 18 7.03164 18 10V12.838C18 14.298 18.931 15.589 20.316 16.052L21 16.279V19H3V16.279L3.684 16.052C5.069 15.589 6 14.298 6 12.838V10C6 7.03164 8.16548 4.56058 11 4.08329V2ZM12 22C10.524 22 9.248 21.19 8.555 20H15.445C14.752 21.19 13.476 22 12 22ZM17.966 17H6.035C7.255 15.998 8 14.486 8 12.838V10C8 7.794 9.794 6 12 6C14.206 6 16 7.794 16 10V12.838C16 14.486 16.745 15.998 17.966 17Z"
+  /></svg>

--- a/app/components/notification-modal.hbs
+++ b/app/components/notification-modal.hbs
@@ -58,7 +58,7 @@
         </AuRadioGroup>
 
         <AuLabel @required={{true}} class="au-u-margin-top">
-          Ik ben geïnteresseerd om 2x per jaar een LPDC statusrapport van {{this.currentSession.group.organizationName}} te ontvangen
+          Ik ben geïnteresseerd om 2x per jaar een LPDC statusrapport van {{organization-name this.currentSession.group}} te ontvangen
         </AuLabel>
         <AuRadioGroup
           @selected={{this.wantsStatusReports}}

--- a/app/components/notification-modal.hbs
+++ b/app/components/notification-modal.hbs
@@ -1,0 +1,115 @@
+<AuModal @modalOpen={{true}} @closeModal={{this.close}} @size="small">
+  <:title>E-mail notificaties</:title>
+  <:body>
+    {{#if (eq this.currentStep 1)}}
+      <p>Je kan er vanaf nu voor kiezen om notificaties via email te krijgen voor instanties die een actie vereisen (bv. Herziening nodig, feedback, ...)</p>
+
+      <AuRadioGroup
+        class="au-u-margin-top-small"
+        @selected={{this.selectedNotificationChoice}}
+        @onChange={{this.handleNotificationChange}}
+        as |Group|>
+        <Group.Radio @value={{true}}>Ja, ik wil notificaties ontvangen</Group.Radio>
+        <Group.Radio @value={{false}}>Nee, ik wil geen notificaties ontvangen</Group.Radio>
+      </AuRadioGroup>
+      <p class="au-u-margin-top">Je kan je keuze steeds wijzigen via de notificatie-instellingen (<AuIcon @icon={{this.AlarmIcon}} />) rechts bovenaan de overzichtspagina van instanties van jouw bestuur.</p>
+
+    {{else if (eq this.currentStep 2)}}
+      <AuButton
+        @skin="link"
+        @icon="nav-left"
+        {{on "click" this.goToPreviousStep}}
+      >
+        Terug naar E-mail notificaties
+      </AuButton>
+
+      <div class="au-u-margin-top-small">
+        <AuLabel @required={{true}}>
+          Emailadres
+        </AuLabel>
+        <AuHelpText
+          @skin="secondary"
+          @size="small"
+          class="au-u-margin-bottom-tiny"
+        >Dit emailadres is overgenomen van je toegekende gebruikersrecht. Pas aan indien nodig.</AuHelpText>
+        <AuInput @width="block" value={{this.emailAddress}} {{on "input" this.updateEmailAddress}}/>
+
+        <AuLabel @required={{true}} class="au-u-margin-top">
+          Vereiste actie
+        </AuLabel>
+        <AuCheckboxGroup
+          @selected={{this.selectedNotificationActions}}
+          @onChange={{this.handleNotificationActionsChange}} as |Group|>
+
+          <Group.Checkbox @value={{this.NOTIFICATION_ACTIONS.REVIEW_STATUS}}>Herziening</Group.Checkbox>
+          <Group.Checkbox @value={{this.NOTIFICATION_ACTIONS.FEEDBACK}}>Feedback</Group.Checkbox>
+          <Group.Checkbox @value={{this.NOTIFICATION_ACTIONS.FORMAL_INFORMAL}}>U/je</Group.Checkbox>
+        </AuCheckboxGroup>
+        <AuLabel @required={{true}} class="au-u-margin-top">
+          Frequentie
+        </AuLabel>
+        <AuRadioGroup
+          @selected={{this.selectedNotificationFrequency}}
+          @onChange={{this.handleNotificationFrequencyChange}}
+          as |Group|>
+          <Group.Radio @value="adhoc">Zodra een instantie een actie vereist ("instant")</Group.Radio>
+          <Group.Radio @value="weekly">1x per week in een overzicht</Group.Radio>
+          <Group.Radio @value="monthly">1x per maand in een overzicht</Group.Radio>
+        </AuRadioGroup>
+
+        <AuLabel @required={{true}} class="au-u-margin-top">
+          Ik ben geïnteresseerd om 2x per jaar een LPDC statusrapport van {{this.currentSession.group.organizationName}} te ontvangen
+        </AuLabel>
+        <AuRadioGroup
+          @selected={{this.wantsStatusReports}}
+          @onChange={{this.handleWantsStatusReportsChange}}
+          as |Group|>
+          <Group.Radio @value={{true}}>Ja</Group.Radio>
+          <Group.Radio @value={{false}}>Nee</Group.Radio>
+        </AuRadioGroup>
+      </div>
+    {{/if}}
+  </:body>
+  <:footer>
+    <AuToolbar @reverse={{true}} @border="none" @size="medium" as |Group|>
+      <Group>
+        {{#if (eq this.currentStep 1)}}
+          <AuButton
+            @skin="secondary"
+            {{on "click" this.makeChoiceLater}}
+          >
+            Later kiezen
+          </AuButton>
+
+          {{#if (eq this.selectedNotificationChoice true)}}
+            <AuButton
+              {{on 'click' this.goToNextStep }}
+            >
+              Volgende
+            </AuButton>
+          {{else}}
+            <AuButton
+              @disabled={{not this.isChoiceMade}}
+              {{on 'click' this.save}}
+            >
+              Bewaren
+            </AuButton>
+          {{/if}}
+        {{else if (eq this.currentStep 2)}}
+          <AuButton
+            @skin="secondary"
+            {{on "click" this.close}}
+          >
+            Annuleren
+          </AuButton>
+          <AuButton
+            @disabled={{this.emptyFormFields}}
+            {{on "click" this.save}}
+          >
+            Bewaren
+          </AuButton>
+        {{/if}}
+      </Group>
+    </AuToolbar>
+  </:footer>
+</AuModal>

--- a/app/components/notification-modal.hbs
+++ b/app/components/notification-modal.hbs
@@ -1,18 +1,32 @@
 <AuModal @modalOpen={{true}} @closeModal={{this.close}} @size="small">
-  <:title>E-mail notificaties</:title>
+  <:title>
+    {{#if (eq this.currentStep 1)}}
+      E-mail notificaties
+    {{else if (eq this.currentStep 2)}}
+      Notificatie-instellingen
+    {{else if (eq this.currentStep 3)}}
+      Selectie instanties
+    {{/if}}
+  </:title>
+
   <:body>
     {{#if (eq this.currentStep 1)}}
-      <p>Je kan er vanaf nu voor kiezen om notificaties via email te krijgen voor instanties die een actie vereisen (bv. Herziening nodig, feedback, ...)</p>
+      <p>Je kan er vanaf nu voor kiezen om notificaties via email te krijgen
+        voor instanties die een actie vereisen (bv. Herziening nodig, feedback,
+        ...)</p>
 
       <AuRadioGroup
         class="au-u-margin-top-small"
         @selected={{this.selectedNotificationChoice}}
         @onChange={{this.handleNotificationChange}}
-        as |Group|>
+        as |Group|
+      >
         <Group.Radio @value={{true}}>Ja, ik wil notificaties ontvangen</Group.Radio>
         <Group.Radio @value={{false}}>Nee, ik wil geen notificaties ontvangen</Group.Radio>
       </AuRadioGroup>
-      <p class="au-u-margin-top">Je kan je keuze steeds wijzigen via de notificatie-instellingen (<AuIcon @icon={{this.AlarmIcon}} />) rechts bovenaan de overzichtspagina van instanties van jouw bestuur.</p>
+      <p class="au-u-margin-top">Je kan je keuze steeds wijzigen via de
+        notificatie-instellingen (<AuIcon @icon={{this.AlarmIcon}} />) rechts
+        bovenaan de overzichtspagina van instanties van jouw bestuur.</p>
 
     {{else if (eq this.currentStep 2)}}
       <AuButton
@@ -31,19 +45,32 @@
           @skin="secondary"
           @size="small"
           class="au-u-margin-bottom-tiny"
-        >Dit e-mailadres is overgenomen van je toegekende gebruikersrecht. Pas aan indien nodig.</AuHelpText>
-        <AuInput @width="block" value={{this.emailAddress}} {{on "input" this.updateEmailAddress}}/>
+        >Dit e-mailadres is overgenomen van je toegekende gebruikersrecht. Pas
+          aan indien nodig.</AuHelpText>
+        <AuInput
+          @width="block"
+          value={{this.emailAddress}}
+          {{on "input" this.updateEmailAddress}}
+        />
 
         <AuLabel @required={{true}} class="au-u-margin-top">
           Vereiste actie
         </AuLabel>
         <AuCheckboxGroup
           @selected={{this.selectedNotificationActions}}
-          @onChange={{this.handleNotificationActionsChange}} as |Group|>
+          @onChange={{this.handleNotificationActionsChange}}
+          as |Group|
+        >
 
-          <Group.Checkbox @value={{this.NOTIFICATION_ACTIONS.REVIEW_STATUS}}>Herziening</Group.Checkbox>
-          <Group.Checkbox @value={{this.NOTIFICATION_ACTIONS.FEEDBACK}}>Feedback</Group.Checkbox>
-          <Group.Checkbox @value={{this.NOTIFICATION_ACTIONS.FORMAL_INFORMAL}}>U/je</Group.Checkbox>
+          <Group.Checkbox
+            @value={{this.NOTIFICATION_ACTIONS.REVIEW_STATUS}}
+          >Herziening</Group.Checkbox>
+          <Group.Checkbox
+            @value={{this.NOTIFICATION_ACTIONS.FEEDBACK}}
+          >Feedback</Group.Checkbox>
+          <Group.Checkbox
+            @value={{this.NOTIFICATION_ACTIONS.FORMAL_INFORMAL}}
+          >U/je</Group.Checkbox>
         </AuCheckboxGroup>
         <AuLabel @required={{true}} class="au-u-margin-top">
           Frequentie
@@ -51,62 +78,67 @@
         <AuRadioGroup
           @selected={{this.selectedNotificationFrequency}}
           @onChange={{this.handleNotificationFrequencyChange}}
-          as |Group|>
-          <Group.Radio @value="adhoc">Zodra een instantie een actie vereist ("instant")</Group.Radio>
+          as |Group|
+        >
+          <Group.Radio @value="adhoc">Zodra een instantie een actie vereist
+            ("instant")</Group.Radio>
           <Group.Radio @value="weekly">1x per week in een overzicht</Group.Radio>
           <Group.Radio @value="monthly">1x per maand in een overzicht</Group.Radio>
         </AuRadioGroup>
 
         <AuLabel @required={{true}} class="au-u-margin-top">
-          Ik ben geïnteresseerd om 2x per jaar een LPDC statusrapport van {{organization-name this.currentSession.group}} te ontvangen
+          Ik ben geïnteresseerd om 2x per jaar een LPDC statusrapport van
+          {{organization-name this.currentSession.group}}
+          te ontvangen
         </AuLabel>
         <AuRadioGroup
           @selected={{this.wantsStatusReports}}
           @onChange={{this.handleWantsStatusReportsChange}}
-          as |Group|>
+          as |Group|
+        >
           <Group.Radio @value={{true}}>Ja</Group.Radio>
           <Group.Radio @value={{false}}>Nee</Group.Radio>
         </AuRadioGroup>
       </div>
+
+      {{! STEP 3 BODY (Pure Info Screen) }}
+    {{else if (eq this.currentStep 3)}}
+      <p>Selecteer nu je instanties door in de overzichtslijst de vakjes aan te
+        vinken. Gebruik de filters in de linkerkolom om je gewenste instanties
+        snel te selecteren.</p>
     {{/if}}
   </:body>
+
   <:footer>
     <AuToolbar @reverse={{true}} @border="none" @size="medium" as |Group|>
       <Group>
         {{#if (eq this.currentStep 1)}}
-          <AuButton
-            @skin="secondary"
-            {{on "click" this.makeChoiceLater}}
-          >
+          <AuButton @skin="secondary" {{on "click" this.makeChoiceLater}}>
             Later kiezen
           </AuButton>
 
           {{#if (eq this.selectedNotificationChoice true)}}
-            <AuButton
-              {{on 'click' this.goToNextStep }}
-            >
+            <AuButton {{on "click" this.goToNextStep}}>
               Volgende
             </AuButton>
           {{else}}
             <AuButton
               @disabled={{not this.isChoiceMade}}
-              {{on 'click' this.save}}
+              {{on "click" this.save}}
             >
               Bewaren
             </AuButton>
           {{/if}}
         {{else if (eq this.currentStep 2)}}
-          <AuButton
-            @skin="secondary"
-            {{on "click" this.close}}
-          >
+          <AuButton @skin="secondary" {{on "click" this.close}}>
             Annuleren
           </AuButton>
-          <AuButton
-            @disabled={{this.emptyFormFields}}
-            {{on "click" this.save}}
-          >
+          <AuButton @disabled={{this.emptyFormFields}} {{on "click" this.save}}>
             Bewaren
+          </AuButton>
+        {{else if (eq this.currentStep 3)}}
+          <AuButton {{on "click" this.close}}>
+            Doorgaan
           </AuButton>
         {{/if}}
       </Group>

--- a/app/components/notification-modal.hbs
+++ b/app/components/notification-modal.hbs
@@ -25,13 +25,13 @@
 
       <div class="au-u-margin-top-small">
         <AuLabel @required={{true}}>
-          Emailadres
+          E-mailadres
         </AuLabel>
         <AuHelpText
           @skin="secondary"
           @size="small"
           class="au-u-margin-bottom-tiny"
-        >Dit emailadres is overgenomen van je toegekende gebruikersrecht. Pas aan indien nodig.</AuHelpText>
+        >Dit e-mailadres is overgenomen van je toegekende gebruikersrecht. Pas aan indien nodig.</AuHelpText>
         <AuInput @width="block" value={{this.emailAddress}} {{on "input" this.updateEmailAddress}}/>
 
         <AuLabel @required={{true}} class="au-u-margin-top">

--- a/app/components/notification-modal.js
+++ b/app/components/notification-modal.js
@@ -1,0 +1,121 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import {
+  NOTIFICATION_ACTIONS,
+  STATUS_REPORT,
+} from 'frontend-lpdc/models/notification-preference';
+import AlarmIcon from './icons/alarm';
+
+export default class NotificationModalComponent extends Component {
+  @service currentSession;
+  @tracked currentStep = 1;
+  @tracked selectedNotificationChoice = null;
+  @tracked selectedNotificationActions = null;
+  @tracked selectedNotificationFrequency = null;
+  @tracked wantsStatusReports = null;
+  @tracked emailAddress = '';
+  NOTIFICATION_ACTIONS = NOTIFICATION_ACTIONS;
+  AlarmIcon = AlarmIcon;
+
+  constructor() {
+    super(...arguments);
+
+    const preference = this.args.data.notificationPreference;
+    if (preference) {
+      this.selectedNotificationChoice = preference.notificationsEnabled;
+      this.emailAddress = preference.emailAddress;
+      this.currentStep = this.selectedNotificationChoice ? 2 : 1;
+      if (preference.notificationsEnabled) this.loadRuleConfigs(preference);
+    } else {
+      this.emailAddress = this.currentSession.user.mailAdres;
+    }
+  }
+
+  async loadRuleConfigs(preference) {
+    const ruleConfigs = await preference.notificationRuleConfigs;
+    this.selectedNotificationActions = ruleConfigs
+      .filter((rc) => rc.notificationRule !== STATUS_REPORT)
+      .map((rc) => rc.notificationRule);
+
+    const actionConfig = ruleConfigs.find(
+      (rc) => rc.notificationRule !== STATUS_REPORT,
+    );
+    this.selectedNotificationFrequency = actionConfig?.frequency ?? null;
+    this.wantsStatusReports = ruleConfigs.some(
+      (rc) => rc.notificationRule === STATUS_REPORT,
+    );
+  }
+
+  get isChoiceMade() {
+    return this.selectedNotificationChoice !== null;
+  }
+
+  get emptyFormFields() {
+    return (
+      !this.emailAddress ||
+      this.selectedNotificationFrequency === null ||
+      this.selectedNotificationActions === null ||
+      this.selectedNotificationActions.length === 0 ||
+      this.wantsStatusReports === null
+    );
+  }
+
+  @action
+  updateEmailAddress(event) {
+    this.emailAddress = event.target.value;
+  }
+
+  @action
+  handleNotificationActionsChange(value) {
+    this.selectedNotificationActions = value;
+  }
+
+  @action
+  handleNotificationFrequencyChange(value) {
+    this.selectedNotificationFrequency = value;
+  }
+
+  @action
+  handleWantsStatusReportsChange(value) {
+    this.wantsStatusReports = value;
+  }
+
+  @action
+  save() {
+    this.args.data.submitHandler(
+      this.selectedNotificationChoice,
+      this.emailAddress,
+      this.selectedNotificationActions,
+      this.selectedNotificationFrequency,
+      this.wantsStatusReports,
+    );
+    this.close();
+  }
+
+  @action
+  goToNextStep() {
+    this.currentStep = 2;
+  }
+  @action
+  goToPreviousStep() {
+    this.currentStep = 1;
+  }
+
+  @action
+  handleNotificationChange(choice) {
+    this.selectedNotificationChoice = choice;
+  }
+
+  @action
+  makeChoiceLater() {
+    this.args.data.makeChoiceLaterHandler();
+    this.close();
+  }
+
+  @action
+  close() {
+    this.args.close();
+  }
+}

--- a/app/components/notification-modal.js
+++ b/app/components/notification-modal.js
@@ -91,13 +91,19 @@ export default class NotificationModalComponent extends Component {
       this.selectedNotificationFrequency,
       this.wantsStatusReports,
     );
-    this.close();
+
+    if (this.currentStep === 2) {
+      this.goToNextStep();
+    } else {
+      this.close();
+    }
   }
 
   @action
   goToNextStep() {
-    this.currentStep = 2;
+    this.currentStep++;
   }
+
   @action
   goToPreviousStep() {
     this.currentStep = 1;

--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -265,17 +265,11 @@ export default class PublicServicesIndexController extends Controller {
 
   @action
   async handleNotificationChange(publicService, isChecked) {
-    const preference = await this.notification.getNotificationPreference();
-    const instances = await preference.instances;
-
     if (isChecked) {
-      preference.instances = [...instances, publicService];
+      await this.notification.addInstance(publicService);
     } else {
-      preference.instances = instances.filter(
-        (instance) => instance !== publicService,
-      );
+      await this.notification.removeInstance(publicService);
     }
-    await preference.save();
   }
 
   @action

--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -25,7 +25,7 @@ export default class PublicServicesIndexController extends Controller {
   @tracked lastModifierIds = [];
   serviceNeedsReview = serviceNeedsReview;
   @service modals;
-  @service notification;
+  @service('notification') notificationService;
   @service currentSession;
   @service store;
   @tracked notificationInstances = [];
@@ -254,7 +254,8 @@ export default class PublicServicesIndexController extends Controller {
   }
 
   async loadNotificationInstances() {
-    const preference = await this.notification.getNotificationPreference();
+    const preference =
+      await this.notificationService.getNotificationPreference();
     if (preference) {
       const instances = await preference.instances;
       this.notificationInstances = Object.fromEntries(
@@ -266,22 +267,20 @@ export default class PublicServicesIndexController extends Controller {
   @action
   async handleNotificationChange(publicService, isChecked) {
     if (isChecked) {
-      await this.notification.addInstance(publicService);
+      await this.notificationService.addInstance(publicService);
     } else {
-      await this.notification.removeInstance(publicService);
+      await this.notificationService.removeInstance(publicService);
     }
   }
 
   @action
   async openNotificationModal() {
-    const preferences = await this.store.query('notification-preference', {
-      'filter[gebruiker][:id:]': this.currentSession.user.id,
-    });
-    const preference = preferences[0];
+    const preference =
+      await this.notificationService.getNotificationPreference();
     this.modals.open(NotificationModal, {
       notificationPreference: preference,
       makeChoiceLaterHandler: () => {
-        this.notification.makeChoiceLater();
+        this.notificationService.makeChoiceLater();
       },
       submitHandler: async (
         selectedNotificationChoice,
@@ -290,13 +289,14 @@ export default class PublicServicesIndexController extends Controller {
         selectedNotificationFrequency,
         wantsStatusReports,
       ) => {
-        await this.notification.updateNotificationPreference(
+        await this.notificationService.updateNotificationPreference(
           selectedNotificationChoice,
           emailAddress,
           selectedNotificationActions,
           selectedNotificationFrequency,
           wantsStatusReports,
         );
+        await this.loadNotificationInstances();
       },
     });
   }

--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -3,6 +3,9 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { serviceNeedsReview } from 'frontend-lpdc/models/public-service';
+import NotificationModal from 'frontend-lpdc/components/notification-modal';
+import { inject as service } from '@ember/service';
+import AlarmIcon from 'frontend-lpdc/components/icons/alarm';
 
 export default class PublicServicesIndexController extends Controller {
   @tracked search = '';
@@ -12,6 +15,7 @@ export default class PublicServicesIndexController extends Controller {
   @tracked needsConversionFromFormalToInformalFilterEnabled = false;
   @tracked isYourEurope = false;
   @tracked isFeedbackAvailable = false;
+  @tracked isNotificationEnabled = false;
   @tracked forMunicipalityMerger = false;
   @tracked statusIds = [];
   @tracked producttypesIds = [];
@@ -20,6 +24,12 @@ export default class PublicServicesIndexController extends Controller {
   @tracked creatorIds = [];
   @tracked lastModifierIds = [];
   serviceNeedsReview = serviceNeedsReview;
+  @service modals;
+  @service notification;
+  @service currentSession;
+  @service store;
+  @tracked notificationInstances = [];
+  AlarmIcon = AlarmIcon;
 
   get statuses() {
     return this.statusIds.map((statusId) =>
@@ -122,6 +132,7 @@ export default class PublicServicesIndexController extends Controller {
       this.needsConversionFromFormalToInformalFilterEnabled === true ||
       this.isYourEurope === true ||
       this.isFeedbackAvailable === true ||
+      this.isNotificationEnabled === true ||
       this.forMunicipalityMerger === true ||
       this.statuses.length > 0 ||
       this.producttypes.length > 0 ||
@@ -140,6 +151,7 @@ export default class PublicServicesIndexController extends Controller {
     this.needsConversionFromFormalToInformalFilterEnabled = false;
     this.isYourEurope = false;
     this.isFeedbackAvailable = false;
+    this.isNotificationEnabled = false;
     this.forMunicipalityMerger = false;
     this.statusIds = [];
     this.producttypesIds = [];
@@ -178,6 +190,12 @@ export default class PublicServicesIndexController extends Controller {
   @action
   handleFeedbackFilterChange(value) {
     this.isFeedbackAvailable = value;
+    this.resetPagination();
+  }
+
+  @action
+  handleNotificationFilterChange(value) {
+    this.isNotificationEnabled = value;
     this.resetPagination();
   }
 
@@ -233,6 +251,60 @@ export default class PublicServicesIndexController extends Controller {
 
   resetPagination() {
     this.page = 0;
+  }
+
+  async loadNotificationInstances() {
+    const preference = await this.notification.getNotificationPreference();
+    if (preference) {
+      const instances = await preference.instances;
+      this.notificationInstances = Object.fromEntries(
+        instances.map((service) => [service.id, true]),
+      );
+    }
+  }
+
+  @action
+  async handleNotificationChange(publicService, isChecked) {
+    const preference = await this.notification.getNotificationPreference();
+    const instances = await preference.instances;
+
+    if (isChecked) {
+      preference.instances = [...instances, publicService];
+    } else {
+      preference.instances = instances.filter(
+        (instance) => instance !== publicService,
+      );
+    }
+    await preference.save();
+  }
+
+  @action
+  async openNotificationModal() {
+    const preferences = await this.store.query('notification-preference', {
+      'filter[gebruiker][:id:]': this.currentSession.user.id,
+    });
+    const preference = preferences[0];
+    this.modals.open(NotificationModal, {
+      notificationPreference: preference,
+      makeChoiceLaterHandler: () => {
+        this.notification.makeChoiceLater();
+      },
+      submitHandler: async (
+        selectedNotificationChoice,
+        emailAddress,
+        selectedNotificationActions,
+        selectedNotificationFrequency,
+        wantsStatusReports,
+      ) => {
+        await this.notification.updateNotificationPreference(
+          selectedNotificationChoice,
+          emailAddress,
+          selectedNotificationActions,
+          selectedNotificationFrequency,
+          wantsStatusReports,
+        );
+      },
+    });
   }
 }
 

--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -309,7 +309,7 @@ export default class PublicServicesIndexController extends Controller {
 
   get allVisibleInstancesSubscribed() {
     return (
-      this.publicServices.length > 0 &&
+      this.publicServices?.length > 0 &&
       this.publicServices.every(
         (instance) => this.notificationInstances[instance.id],
       )

--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { serviceNeedsReview } from 'frontend-lpdc/models/public-service';
 import NotificationModal from 'frontend-lpdc/components/notification-modal';
+import { buildPublicServiceFilters } from 'frontend-lpdc/utils/public-service-query';
 import { inject as service } from '@ember/service';
 import AlarmIcon from 'frontend-lpdc/components/icons/alarm';
 
@@ -318,64 +319,10 @@ export default class PublicServicesIndexController extends Controller {
   @action
   async subscribeAllInstances() {
     const query = {
+      ...buildPublicServiceFilters(this, this.currentSession),
       'fields[public-services]': 'id',
-      'filter[created-by][:uri:]': this.currentSession.group.uri,
       'page[size]': 9999,
     };
-
-    if (this.search) {
-      query['filter'] = this.search.trim();
-    }
-
-    if (this.isReviewRequiredFilterEnabled) {
-      query['filter[:has:review-status]'] = true;
-    }
-
-    if (this.needsConversionFromFormalToInformalFilterEnabled) {
-      query['filter[needs-conversion-from-formal-to-informal]'] = true;
-    }
-
-    if (this.isYourEurope) {
-      query['filter[publication-media][:uri:]'] =
-        'https://productencatalogus.data.vlaanderen.be/id/concept/PublicatieKanaal/YourEurope';
-    }
-
-    if (this.isFeedbackAvailable) {
-      query['filter[feedback-available]'] = true;
-    }
-
-    if (this.isNotificationEnabled) {
-      query['filter[notification-preferences][gebruiker][:id:]'] =
-        this.currentSession.user.id;
-    }
-
-    if (this.forMunicipalityMerger) {
-      query['filter[for-municipality-merger]'] = true;
-    }
-
-    if (this.statusIds?.length > 0) {
-      query['filter[status][:id:]'] = this.statusIds.join(',');
-    }
-
-    if (this.producttypesIds?.length > 0) {
-      query['filter[type][:id:]'] = this.producttypesIds.join(',');
-    }
-
-    if (this.doelgroepenIds?.length > 0) {
-      query['filter[target-audiences][:id:]'] = this.doelgroepenIds.join(',');
-    }
-
-    if (this.themaIds?.length > 0) {
-      query['filter[thematic-areas][:id:]'] = this.themaIds.join(',');
-    }
-
-    if (this.creatorIds?.length > 0) {
-      query['filter[creator][:id:]'] = this.creatorIds.join(',');
-    }
-
-    if (this.lastModifierIds?.length > 0) {
-      query['filter[last-modifier][:id:]'] = this.lastModifierIds.join(',');
-    }
 
     const allServices = await this.store.query('public-service', query);
 

--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -28,7 +28,7 @@ export default class PublicServicesIndexController extends Controller {
   @service('notification') notificationService;
   @service currentSession;
   @service store;
-  @tracked notificationInstances = [];
+  @tracked notificationInstances = {};
   AlarmIcon = AlarmIcon;
 
   get statuses() {
@@ -266,6 +266,11 @@ export default class PublicServicesIndexController extends Controller {
 
   @action
   async handleNotificationChange(publicService, isChecked) {
+    this.notificationInstances = {
+      ...this.notificationInstances,
+      [publicService.id]: isChecked,
+    };
+
     if (isChecked) {
       await this.notificationService.addInstance(publicService);
     } else {
@@ -299,6 +304,99 @@ export default class PublicServicesIndexController extends Controller {
         await this.loadNotificationInstances();
       },
     });
+  }
+
+  get allVisibleInstancesSubscribed() {
+    return (
+      this.publicServices.length > 0 &&
+      this.publicServices.every(
+        (instance) => this.notificationInstances[instance.id],
+      )
+    );
+  }
+
+  @action
+  async subscribeAllInstances() {
+    const query = {
+      'fields[public-services]': 'id',
+      'filter[created-by][:uri:]': this.currentSession.group.uri,
+      'page[size]': 9999,
+    };
+
+    if (this.search) {
+      query['filter'] = this.search.trim();
+    }
+
+    if (this.isReviewRequiredFilterEnabled) {
+      query['filter[:has:review-status]'] = true;
+    }
+
+    if (this.needsConversionFromFormalToInformalFilterEnabled) {
+      query['filter[needs-conversion-from-formal-to-informal]'] = true;
+    }
+
+    if (this.isYourEurope) {
+      query['filter[publication-media][:uri:]'] =
+        'https://productencatalogus.data.vlaanderen.be/id/concept/PublicatieKanaal/YourEurope';
+    }
+
+    if (this.isFeedbackAvailable) {
+      query['filter[feedback-available]'] = true;
+    }
+
+    if (this.isNotificationEnabled) {
+      query['filter[notification-preferences][gebruiker][:id:]'] =
+        this.currentSession.user.id;
+    }
+
+    if (this.forMunicipalityMerger) {
+      query['filter[for-municipality-merger]'] = true;
+    }
+
+    if (this.statusIds?.length > 0) {
+      query['filter[status][:id:]'] = this.statusIds.join(',');
+    }
+
+    if (this.producttypesIds?.length > 0) {
+      query['filter[type][:id:]'] = this.producttypesIds.join(',');
+    }
+
+    if (this.doelgroepenIds?.length > 0) {
+      query['filter[target-audiences][:id:]'] = this.doelgroepenIds.join(',');
+    }
+
+    if (this.themaIds?.length > 0) {
+      query['filter[thematic-areas][:id:]'] = this.themaIds.join(',');
+    }
+
+    if (this.creatorIds?.length > 0) {
+      query['filter[creator][:id:]'] = this.creatorIds.join(',');
+    }
+
+    if (this.lastModifierIds?.length > 0) {
+      query['filter[last-modifier][:id:]'] = this.lastModifierIds.join(',');
+    }
+
+    const allServices = await this.store.query('public-service', query);
+
+    // if everything (visible) was subscribed we then unsubscribe
+    if (this.allVisibleInstancesSubscribed) {
+      const updated = { ...this.notificationInstances };
+      for (const instance of this.publicServices) {
+        updated[instance.id] = false;
+      }
+      this.notificationInstances = updated;
+
+      await this.notificationService.removeInstances(allServices);
+    } else {
+      const updated = { ...this.notificationInstances };
+      for (const instance of this.publicServices) {
+        updated[instance.id] = true;
+      }
+      this.notificationInstances = updated;
+
+      await this.notificationService.addInstances(allServices);
+    }
   }
 }
 

--- a/app/helpers/organization-name.js
+++ b/app/helpers/organization-name.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function organizationName([organization]) {
+  return `${organization.classificatie.label} ${organization.naam}`;
+}
+
+export default helper(organizationName);

--- a/app/helpers/organization-name.js
+++ b/app/helpers/organization-name.js
@@ -1,7 +1,3 @@
-import { helper } from '@ember/component/helper';
-
-export function organizationName([organization]) {
+export default function organizationName(organization) {
   return `${organization.classificatie.label} ${organization.naam}`;
 }
-
-export default helper(organizationName);

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -16,4 +16,8 @@ export default class Bestuurseenheid extends Model {
     class: 'http://data.vlaanderen.be/ns/besluit#Bestuurseenheid',
     classificatie: 'http://data.vlaanderen.be/ns/besluit#classificatie',
   };
+
+  get organizationName() {
+    return `${this.classificatie.label} ${this.naam}`;
+  }
 }

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -16,8 +16,4 @@ export default class Bestuurseenheid extends Model {
     class: 'http://data.vlaanderen.be/ns/besluit#Bestuurseenheid',
     classificatie: 'http://data.vlaanderen.be/ns/besluit#classificatie',
   };
-
-  get organizationName() {
-    return `${this.classificatie.label} ${this.naam}`;
-  }
 }

--- a/app/models/gebruiker.js
+++ b/app/models/gebruiker.js
@@ -4,8 +4,7 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class GebruikerModel extends Model {
   @attr voornaam;
   @attr achternaam;
-  @attr rijksregisterNummer;
-  @attr email;
+  @attr mailAdres;
   @hasMany('account', {
     async: true,
     inverse: null,

--- a/app/models/gebruiker.js
+++ b/app/models/gebruiker.js
@@ -5,6 +5,7 @@ export default class GebruikerModel extends Model {
   @attr voornaam;
   @attr achternaam;
   @attr rijksregisterNummer;
+  @attr email;
   @hasMany('account', {
     async: true,
     inverse: null,

--- a/app/models/gebruiker.js
+++ b/app/models/gebruiker.js
@@ -1,5 +1,5 @@
 /* eslint-disable ember/no-get, ember/classic-decorator-no-classic-methods */
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 
 export default class GebruikerModel extends Model {
   @attr voornaam;
@@ -15,6 +15,11 @@ export default class GebruikerModel extends Model {
     inverse: null,
   })
   bestuurseenheden;
+  @belongsTo('notification-preference', {
+    async: true,
+    inverse: 'gebruiker',
+  })
+  notificationPreference;
 
   get group() {
     return this.hasMany('bestuurseenheden').value()?.[0];

--- a/app/models/notification-preference.js
+++ b/app/models/notification-preference.js
@@ -12,7 +12,7 @@ export default class NotificationPreferenceModel extends Model {
 
   @hasMany('notification-rule-config', {
     async: true,
-    inverse: null,
+    inverse: 'notificationPreference',
   })
   notificationRuleConfigs;
 

--- a/app/models/notification-preference.js
+++ b/app/models/notification-preference.js
@@ -1,0 +1,36 @@
+import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
+
+export default class NotificationPreferenceModel extends Model {
+  @attr('boolean') notificationsEnabled;
+  @attr emailAddress;
+
+  @belongsTo('gebruiker', {
+    async: true,
+    inverse: 'notificationPreference',
+  })
+  gebruiker;
+
+  @hasMany('notification-rule-config', {
+    async: true,
+    inverse: null,
+  })
+  notificationRuleConfigs;
+
+  @hasMany('public-service', {
+    async: true,
+    inverse: 'notificationPreferences',
+  })
+  instances;
+}
+
+export const NOTIFICATION_ACTIONS = {
+  FEEDBACK:
+    'http://lblod.data.gift/concepts/60cd1b30-fa29-4fd9-a618-2f8566153849',
+  REVIEW_STATUS:
+    'http://lblod.data.gift/concepts/83d7bade-9b45-4d28-9348-3edcdcf99edc',
+  FORMAL_INFORMAL:
+    'http://lblod.data.gift/concepts/906311f3-f9f0-4b02-80de-d339df39a4ad',
+};
+
+export const STATUS_REPORT =
+  'http://lblod.data.gift/concepts/634522c3-f5bd-4f53-82d3-983b7cbbdb10';

--- a/app/models/notification-preference.js
+++ b/app/models/notification-preference.js
@@ -10,6 +10,12 @@ export default class NotificationPreferenceModel extends Model {
   })
   gebruiker;
 
+  @belongsTo('bestuurseenheid', {
+    async: true,
+    inverse: null,
+  })
+  bestuurseenheid;
+
   @hasMany('notification-rule-config', {
     async: true,
     inverse: 'notificationPreference',

--- a/app/models/notification-rule-config.js
+++ b/app/models/notification-rule-config.js
@@ -1,0 +1,9 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class NotificationRuleConfigModel extends Model {
+  @attr frequency;
+  @attr notificationRule;
+
+  @belongsTo('notification-preference', { async: true, inverse: null })
+  notificationPreference;
+}

--- a/app/models/notification-rule-config.js
+++ b/app/models/notification-rule-config.js
@@ -4,6 +4,9 @@ export default class NotificationRuleConfigModel extends Model {
   @attr frequency;
   @attr notificationRule;
 
-  @belongsTo('notification-preference', { async: true, inverse: null })
+  @belongsTo('notification-preference', {
+    async: true,
+    inverse: 'notificationRuleConfigs',
+  })
   notificationPreference;
 }

--- a/app/models/public-service.js
+++ b/app/models/public-service.js
@@ -75,6 +75,12 @@ export default class PublicServiceModel extends Model {
   })
   feedback;
 
+  @hasMany('notification-preference', {
+    async: true,
+    inverse: 'instances',
+  })
+  notificationPreferences;
+
   get isSent() {
     return (
       this.status?.uri ===

--- a/app/routes/auth/login.js
+++ b/app/routes/auth/login.js
@@ -6,10 +6,12 @@ export default class AuthLoginRoute extends Route {
   @service router;
   @service session;
   @service formalInformalChoice;
+  @service notification;
 
   beforeModel() {
     if (this.session.prohibitAuthentication('public-services')) {
       this.formalInformalChoice.enableChoiceIfNotPreviouslyConfirmed();
+      this.notification.enableChoiceIfNotPreviouslyConfirmed();
       if (isValidAcmidmConfig(ENV.acmidm)) {
         window.location.replace(buildLoginUrl(ENV.acmidm));
       } else {

--- a/app/routes/public-services/index.js
+++ b/app/routes/public-services/index.js
@@ -76,12 +76,7 @@ export default class PublicServicesIndexRoute extends Route {
       });
     }
     if (!(await this.notificationService.isChoiceMade())) {
-      const preferences = await this.store.query('notification-preference', {
-        'filter[gebruiker][:id:]': this.currentSession.user.id,
-      });
-      const preference = preferences[0];
       this.modals.open(NotificationModal, {
-        notificationPreference: preference,
         makeChoiceLaterHandler: () => {
           this.notificationService.makeChoiceLater();
         },

--- a/app/routes/public-services/index.js
+++ b/app/routes/public-services/index.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 import SelectUOrJeModal from 'frontend-lpdc/components/select-u-or-je-modal';
+import NotificationModal from 'frontend-lpdc/components/notification-modal';
 
 export default class PublicServicesIndexRoute extends Route {
   @service store;
@@ -9,6 +10,7 @@ export default class PublicServicesIndexRoute extends Route {
   @service modals;
   @service formalInformalChoice;
   @service('public-service') publicServiceService;
+  @service('notification') notificationService;
 
   queryParams = {
     search: {
@@ -31,6 +33,9 @@ export default class PublicServicesIndexRoute extends Route {
       refreshModel: true,
     },
     isFeedbackAvailable: {
+      refreshModel: true,
+    },
+    isNotificationEnabled: {
       refreshModel: true,
     },
     forMunicipalityMerger: {
@@ -70,6 +75,33 @@ export default class PublicServicesIndexRoute extends Route {
         },
       });
     }
+    if (!(await this.notificationService.isChoiceMade())) {
+      const preferences = await this.store.query('notification-preference', {
+        'filter[gebruiker][:id:]': this.currentSession.user.id,
+      });
+      const preference = preferences[0];
+      this.modals.open(NotificationModal, {
+        notificationPreference: preference,
+        makeChoiceLaterHandler: () => {
+          this.notificationService.makeChoiceLater();
+        },
+        submitHandler: async (
+          selectedNotificationChoice,
+          emailAddress,
+          selectedNotificationActions,
+          selectedNotificationFrequency,
+          wantsStatusReports,
+        ) => {
+          await this.notificationService.updateNotificationPreference(
+            selectedNotificationChoice,
+            emailAddress,
+            selectedNotificationActions,
+            selectedNotificationFrequency,
+            wantsStatusReports,
+          );
+        },
+      });
+    }
   }
 
   async model(params) {
@@ -79,6 +111,11 @@ export default class PublicServicesIndexRoute extends Route {
       loadPublicServices: this.loadPublicServicesTask.perform(params),
       loadedPublicServices: this.loadPublicServicesTask.lastSuccessful?.value,
     };
+  }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    controller.loadNotificationInstances();
   }
 
   loadPublicServicesTask = restartableTask(
@@ -91,6 +128,7 @@ export default class PublicServicesIndexRoute extends Route {
       isYourEurope,
       forMunicipalityMerger,
       isFeedbackAvailable,
+      isNotificationEnabled,
       doelgroepenIds,
       producttypesIds,
       themaIds,
@@ -130,6 +168,11 @@ export default class PublicServicesIndexRoute extends Route {
 
       if (isFeedbackAvailable) {
         query['filter[feedback-available]'] = true;
+      }
+
+      if (isNotificationEnabled) {
+        query['filter[notification-preferences][gebruiker][:id:]'] =
+          this.currentSession.user.id;
       }
 
       if (forMunicipalityMerger) {

--- a/app/routes/public-services/index.js
+++ b/app/routes/public-services/index.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 import SelectUOrJeModal from 'frontend-lpdc/components/select-u-or-je-modal';
 import NotificationModal from 'frontend-lpdc/components/notification-modal';
+import { buildPublicServiceFilters } from 'frontend-lpdc/utils/public-service-query';
 
 export default class PublicServicesIndexRoute extends Route {
   @service store;
@@ -113,92 +114,20 @@ export default class PublicServicesIndexRoute extends Route {
     controller.loadNotificationInstances();
   }
 
-  loadPublicServicesTask = restartableTask(
-    async ({
-      search,
-      page,
-      sort,
-      isReviewRequiredFilterEnabled,
-      needsConversionFromFormalToInformalFilterEnabled,
-      isYourEurope,
-      forMunicipalityMerger,
-      isFeedbackAvailable,
-      isNotificationEnabled,
-      doelgroepenIds,
-      producttypesIds,
-      themaIds,
-      creatorIds,
-      lastModifierIds,
-      statusIds,
-    }) => {
-      const query = {
-        'filter[created-by][:uri:]': this.currentSession.group.uri,
-        'page[number]': page,
-        'fields[public-services]':
-          'name,product-id,type,target-audiences,thematic-areas,publication-media,date-created,date-modified,status,needs-conversion-from-formal-to-informal,review-status,for-municipality-merger,feedback-available',
-        include:
-          'type,target-audiences,thematic-areas,publication-media,status,review-status,creator,last-modifier',
-      };
+  loadPublicServicesTask = restartableTask(async (params) => {
+    const query = {
+      ...buildPublicServiceFilters(params, this.currentSession),
+      'page[number]': params.page,
+      'fields[public-services]':
+        'name,product-id,type,target-audiences,thematic-areas,publication-media,date-created,date-modified,status,needs-conversion-from-formal-to-informal,review-status,for-municipality-merger,feedback-available',
+      include:
+        'type,target-audiences,thematic-areas,publication-media,status,review-status,creator,last-modifier',
+    };
 
-      if (search) {
-        query['filter'] = search.trim();
-      }
+    if (params.sort) {
+      query.sort = params.sort;
+    }
 
-      if (sort) {
-        query.sort = sort;
-      }
-
-      if (isReviewRequiredFilterEnabled) {
-        query['filter[:has:review-status]'] = true;
-      }
-
-      if (needsConversionFromFormalToInformalFilterEnabled) {
-        query['filter[needs-conversion-from-formal-to-informal]'] = true;
-      }
-
-      if (isYourEurope) {
-        query['filter[publication-media][:uri:]'] =
-          'https://productencatalogus.data.vlaanderen.be/id/concept/PublicatieKanaal/YourEurope';
-      }
-
-      if (isFeedbackAvailable) {
-        query['filter[feedback-available]'] = true;
-      }
-
-      if (isNotificationEnabled) {
-        query['filter[notification-preferences][gebruiker][:id:]'] =
-          this.currentSession.user.id;
-      }
-
-      if (forMunicipalityMerger) {
-        query['filter[for-municipality-merger]'] = true;
-      }
-
-      if (statusIds?.length > 0) {
-        query['filter[status][:id:]'] = statusIds.join(',');
-      }
-
-      if (producttypesIds?.length > 0) {
-        query['filter[type][:id:]'] = producttypesIds.join(',');
-      }
-
-      if (doelgroepenIds?.length > 0) {
-        query['filter[target-audiences][:id:]'] = doelgroepenIds.join(',');
-      }
-
-      if (themaIds?.length > 0) {
-        query['filter[thematic-areas][:id:]'] = themaIds.join(',');
-      }
-
-      if (creatorIds?.length > 0) {
-        query['filter[creator][:id:]'] = creatorIds.join(',');
-      }
-
-      if (lastModifierIds?.length > 0) {
-        query['filter[last-modifier][:id:]'] = lastModifierIds.join(',');
-      }
-
-      return await this.store.query('public-service', query);
-    },
-  );
+    return await this.store.query('public-service', query);
+  });
 }

--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -67,7 +67,10 @@ export default class NotificationService extends Service {
       });
     } else {
       // clear out whatever rule-configs already exist before rebuilding
-      preference.notificationRuleConfigs = [];
+      const oldRuleConfigs = Array.from(
+        await preference.notificationRuleConfigs,
+      );
+      await Promise.all(oldRuleConfigs.map((config) => config.destroyRecord()));
     }
 
     preference.notificationsEnabled = wantsNotifications;
@@ -80,7 +83,6 @@ export default class NotificationService extends Service {
         frequency,
         wantsStatusReports,
       );
-      await preference.hasMany('notificationRuleConfigs').reload();
     }
     return preference;
   }

--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -37,6 +37,22 @@ export default class NotificationService extends Service {
     localStorage.removeItem('makeNotificationPreferenceLater');
   }
 
+  async addInstance(instance) {
+    const preference = await this.getNotificationPreference();
+    const instances = await preference.instances;
+
+    preference.instances = [...instances, instance];
+    await preference.save();
+  }
+
+  async removeInstance(instance) {
+    const preference = await this.getNotificationPreference();
+    const instances = await preference.instances;
+
+    preference.instances = instances.filter((i) => i !== instance);
+    await preference.save();
+  }
+
   async updateNotificationPreference(
     wantsNotifications,
     emailAddress,
@@ -44,7 +60,7 @@ export default class NotificationService extends Service {
     frequency,
     wantsStatusReports,
   ) {
-    let preference = await this.currentSession.user.notificationPreference;
+    let preference = await this.getNotificationPreference();
     if (!preference) {
       preference = this.store.createRecord('notification-preference', {
         gebruiker: this.currentSession.user,

--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -1,6 +1,7 @@
 import Service, { inject as service } from '@ember/service';
 import { STATUS_REPORT } from 'frontend-lpdc/models/notification-preference';
 import { tracked } from '@glimmer/tracking';
+import { assert } from '@ember/debug';
 
 export default class NotificationService extends Service {
   @service store;
@@ -24,7 +25,10 @@ export default class NotificationService extends Service {
       return this.notificationPreference;
     }
 
-    if (!this.currentSession.user) return null;
+    assert(
+      'Expected currentSession.user to be loaded before fetching notification preferences.',
+      this.currentSession.user,
+    );
 
     const preferences = await this.store.query('notification-preference', {
       'filter[gebruiker][:id:]': this.currentSession.user.id,

--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -15,6 +15,10 @@ export default class NotificationService extends Service {
     );
   }
 
+  get isNotificationsEnabled() {
+    return this.notificationPreference?.notificationsEnabled === true;
+  }
+
   async getNotificationPreference() {
     if (this.notificationPreference) {
       return this.notificationPreference;
@@ -84,6 +88,7 @@ export default class NotificationService extends Service {
         wantsStatusReports,
       );
     }
+    this.notificationPreference = preference;
     return preference;
   }
 

--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -1,0 +1,93 @@
+import Service, { inject as service } from '@ember/service';
+import { STATUS_REPORT } from 'frontend-lpdc/models/notification-preference';
+import { tracked } from '@glimmer/tracking';
+
+export default class NotificationService extends Service {
+  @service store;
+  @service currentSession;
+  @tracked notificationPreference = null;
+
+  async isChoiceMade() {
+    const preference = await this.getNotificationPreference();
+    return (
+      preference !== undefined ||
+      localStorage.getItem('makeNotificationPreferenceLater') === 'true'
+    );
+  }
+
+  async getNotificationPreference() {
+    if (this.notificationPreference) {
+      return this.notificationPreference;
+    }
+
+    if (!this.currentSession.user) return null;
+
+    const preferences = await this.store.query('notification-preference', {
+      'filter[gebruiker][:id:]': this.currentSession.user.id,
+    });
+    this.notificationPreference = preferences[0];
+    return this.notificationPreference;
+  }
+
+  makeChoiceLater() {
+    localStorage.setItem('makeNotificationPreferenceLater', 'true');
+  }
+
+  enableChoiceIfNotPreviouslyConfirmed() {
+    localStorage.removeItem('makeNotificationPreferenceLater');
+  }
+
+  async updateNotificationPreference(
+    wantsNotifications,
+    emailAddress,
+    actions,
+    frequency,
+    wantsStatusReports,
+  ) {
+    let preference = await this.currentSession.user.notificationPreference;
+    if (!preference) {
+      preference = this.store.createRecord('notification-preference', {
+        gebruiker: this.currentSession.user,
+      });
+    } else {
+      // clear out whatever rule-configs already exist before rebuilding
+      preference.notificationRuleConfigs = [];
+    }
+
+    preference.notificationsEnabled = wantsNotifications;
+    preference.emailAddress = emailAddress;
+    await preference.save();
+    if (wantsNotifications) {
+      await this.createRuleConfigs(
+        preference,
+        actions,
+        frequency,
+        wantsStatusReports,
+      );
+      await preference.hasMany('notificationRuleConfigs').reload();
+    }
+    return preference;
+  }
+
+  async createRuleConfigs(preference, actions, frequency, wantsStatusReports) {
+    const configs = actions.map((notificationRule) =>
+      this.store.createRecord('notification-rule-config', {
+        notificationRule,
+        frequency,
+        notificationPreference: preference,
+      }),
+    );
+
+    if (wantsStatusReports) {
+      configs.push(
+        this.store.createRecord('notification-rule-config', {
+          notificationRule: STATUS_REPORT,
+          frequency: 'bi-annual', //TODO: figure out how we'll do this
+          notificationPreference: preference,
+        }),
+      );
+    }
+
+    return Promise.all(configs.map((config) => config.save()));
+  }
+}

--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -20,8 +20,8 @@ export default class NotificationService extends Service {
     return this.notificationPreference?.notificationsEnabled === true;
   }
 
-  async getNotificationPreference() {
-    if (this.notificationPreference) {
+  async getNotificationPreference(reloadNotificationPreference = false) {
+    if (this.notificationPreference && !reloadNotificationPreference) {
       return this.notificationPreference;
     }
 

--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -32,6 +32,7 @@ export default class NotificationService extends Service {
 
     const preferences = await this.store.query('notification-preference', {
       'filter[gebruiker][:id:]': this.currentSession.user.id,
+      include: 'gebruiker,instances',
     });
     this.notificationPreference = preferences[0];
     return this.notificationPreference;
@@ -53,11 +54,26 @@ export default class NotificationService extends Service {
     await preference.save();
   }
 
+  async addInstances(newInstances) {
+    const preference = await this.getNotificationPreference();
+    const instances = await preference.instances;
+    preference.instances = [...new Set([...instances, ...newInstances])];
+    await preference.save();
+  }
+
   async removeInstance(instance) {
     const preference = await this.getNotificationPreference();
     const instances = await preference.instances;
 
     preference.instances = instances.filter((i) => i !== instance);
+    await preference.save();
+  }
+
+  async removeInstances(instancesToRemove) {
+    const preference = await this.getNotificationPreference();
+    const instances = await preference.instances;
+    const removeIds = new Set(instancesToRemove.map((i) => i.id));
+    preference.instances = instances.filter((i) => !removeIds.has(i.id));
     await preference.save();
   }
 

--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -72,6 +72,7 @@ export default class NotificationService extends Service {
     if (!preference) {
       preference = this.store.createRecord('notification-preference', {
         gebruiker: this.currentSession.user,
+        bestuurseenheid: this.currentSession.group,
       });
     } else {
       // clear out whatever rule-configs already exist before rebuilding

--- a/app/services/public-service.js
+++ b/app/services/public-service.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 export default class PublicServiceService extends Service {
   @service store;
   @service('concept') conceptService;
+  @service('notification') notificationService;
   @service toaster;
 
   httpRequest = new HttpRequest(this.toaster);
@@ -151,6 +152,7 @@ export default class PublicServiceService extends Service {
       '/lpdc-management/public-services',
       conceptId ? { conceptId: conceptId } : {},
     );
+    await this.notificationService.getNotificationPreference(true);
     return responseBody.data.id;
   }
 

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -180,6 +180,7 @@
           @icon={{this.AlarmIcon}}
           @skin="secondary"
           @hideText={{true}}
+          @text="Notificaties"
           {{on "click" this.openNotificationModal}}
         />
       </Group>

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -14,37 +14,55 @@
         <AuLabel>Toon enkel</AuLabel>
         <AuCheckbox
           @checked={{this.isReviewRequiredFilterEnabled}}
-          @onChange={{this.toggleReviewRequiredFilter}}>
+          @onChange={{this.toggleReviewRequiredFilter}}
+        >
           Herziening nodig
         </AuCheckbox>
         {{#if this.isChosenFormInformal}}
-            <AuCheckbox
+          <AuCheckbox
             @checked={{this.needsConversionFromFormalToInformalFilterEnabled}}
-            @onChange={{this.toggleNeedsConversionFromFormalToInformalFilter}}>
+            @onChange={{this.toggleNeedsConversionFromFormalToInformalFilter}}
+          >
             u→je omzetting nodig
           </AuCheckbox>
         {{/if}}
         <AuCheckbox
           @checked={{this.isYourEurope}}
-          @onChange={{this.handleYourEuropeFilterChange}}>
+          @onChange={{this.handleYourEuropeFilterChange}}
+        >
           Your Europe
         </AuCheckbox>
         <AuCheckbox
           @checked={{this.isFeedbackAvailable}}
-          @onChange={{this.handleFeedbackFilterChange}}>
+          @onChange={{this.handleFeedbackFilterChange}}
+        >
           Feedback beschikbaar
         </AuCheckbox>
-        {{#if (and (is-feature-enabled "fusies") this.municipalityHasForMunicipalityMergerInstances)}}
+        <AuCheckbox
+          @checked={{this.isNotification}}
+          @onChange={{this.handleNotificationFilterChange}}
+        >
+          Notificaties
+        </AuCheckbox>
+        {{#if
+          (and
+            (is-feature-enabled "fusies")
+            this.municipalityHasForMunicipalityMergerInstances
+          )
+        }}
           <AuCheckbox
             @checked={{this.forMunicipalityMerger}}
-            @onChange={{this.handleForMunicipalityMergerFilterChange}}>
+            @onChange={{this.handleForMunicipalityMergerFilterChange}}
+          >
             Bestemd voor fusie
           </AuCheckbox>
         {{/if}}
       </div>
       <div>
         <AuLabel>Filter op eigenschappen</AuLabel>
-        <label class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light">
+        <label
+          class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light"
+        >
           Status
         </label>
         <PowerSelectMultiple
@@ -52,10 +70,13 @@
           @selected={{this.statuses}}
           @onChange={{this.handleStatusesFilterChange}}
           @searchField="label"
-          as |status|>
+          as |status|
+        >
           {{status.label}}
         </PowerSelectMultiple>
-        <label class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light">
+        <label
+          class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light"
+        >
           Producttype
         </label>
         <PowerSelectMultiple
@@ -63,10 +84,13 @@
           @selected={{this.producttypes}}
           @onChange={{this.handleProducttypesFilterChange}}
           @searchField="label"
-          as |producttype|>
+          as |producttype|
+        >
           {{producttype.label}}
         </PowerSelectMultiple>
-        <label class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light">
+        <label
+          class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light"
+        >
           Doelgroepen
         </label>
         <PowerSelectMultiple
@@ -74,10 +98,13 @@
           @selected={{this.doelgroepen}}
           @onChange={{this.handleDoelgroepenFilterChange}}
           @searchField="label"
-          as |doelgroep|>
+          as |doelgroep|
+        >
           {{doelgroep.label}}
         </PowerSelectMultiple>
-        <label class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light">
+        <label
+          class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light"
+        >
           Thema's
         </label>
         <PowerSelectMultiple
@@ -85,10 +112,13 @@
           @selected={{this.themas}}
           @onChange={{this.handleThemasFilterChange}}
           @searchField="label"
-          as |thema|>
+          as |thema|
+        >
           {{thema.label}}
         </PowerSelectMultiple>
-        <label class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light">
+        <label
+          class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light"
+        >
           Aangemaakt door
         </label>
         <PowerSelectMultiple
@@ -97,10 +127,13 @@
           @onChange={{this.handleCreatorsFilterChange}}
           @searchEnabled={{true}}
           @searchField="fullName"
-          as |creator|>
+          as |creator|
+        >
           {{creator.fullName}}
         </PowerSelectMultiple>
-        <label class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light">
+        <label
+          class="au-u-margin-top-small au-u-margin-bottom-tiny au-c-label au-u-light"
+        >
           Laatst bewerkt door
         </label>
         <PowerSelectMultiple
@@ -109,13 +142,18 @@
           @onChange={{this.handleLastModifiersFilterChange}}
           @searchEnabled={{true}}
           @searchField="fullName"
-          as |lastModifier|>
+          as |lastModifier|
+        >
           {{lastModifier.fullName}}
         </PowerSelectMultiple>
       </div>
       {{#if this.hasActiveFilters}}
         <div class="au-u-text-left@medium">
-          <AuButton @icon="cross" @skin="secondary" {{on "click" this.resetFilters}}>
+          <AuButton
+            @icon="cross"
+            @skin="secondary"
+            {{on "click" this.resetFilters}}
+          >
             Wis filters
           </AuButton>
         </div>
@@ -138,6 +176,12 @@
         >
           Product of dienst toevoegen
         </AuLink>
+        <AuButton
+          @icon={{this.AlarmIcon}}
+          @skin="secondary"
+          @hideText={{true}}
+          {{on "click" this.openNotificationModal}}
+        />
       </Group>
     </AuToolbar>
     <AuDataTable
@@ -149,6 +193,9 @@
     >
       <Table.content as |Content|>
         <Content.header>
+          <th>
+            <AuIcon @icon={{this.AlarmIcon}} />
+          </th>
           <th>
             Productnaam
           </th>
@@ -181,11 +228,11 @@
 
         {{#if this.showTableLoader}}
           <tbody>
-          <tr>
-            <td colspan="100%" class="au-c-data-table__message">
-              <AuLoader @padding="small" />
-            </td>
-          </tr>
+            <tr>
+              <td colspan="100%" class="au-c-data-table__message">
+                <AuLoader @padding="small" />
+              </td>
+            </tr>
           </tbody>
         {{else if this.hasErrored}}
           <tr>
@@ -202,6 +249,12 @@
         {{else if this.hasResults}}
           <Content.body as |publicService|>
             <td>
+              <AuCheckbox
+                @checked={{get this.notificationInstances publicService.id}}
+                @onChange={{fn this.handleNotificationChange publicService}}
+              />
+            </td>
+            <td>
               {{! template-lint-disable no-triple-curlies~}}
               <AuLink
                 @skin="primary"
@@ -210,8 +263,17 @@
               >
                 {{publicService.nameNlOrGeenTitel}}
               </AuLink>
-              {{#if (and (is-feature-enabled "fusies") publicService.forMunicipalityMerger)}}
-                <AuPill @skin="success" @size="small" @icon="users-four-of-four">
+              {{#if
+                (and
+                  (is-feature-enabled "fusies")
+                  publicService.forMunicipalityMerger
+                )
+              }}
+                <AuPill
+                  @skin="success"
+                  @size="small"
+                  @icon="users-four-of-four"
+                >
                   fusie
                 </AuPill>
               {{/if}}
@@ -236,21 +298,30 @@
             </td>
             <td>{{publicService.type.label}}</td>
             <td>
-              <PillList @list={{await publicService.targetAudiencesOrderedOnLabel}} as |targetAudience|>
+              <PillList
+                @list={{await publicService.targetAudiencesOrderedOnLabel}}
+                as |targetAudience|
+              >
                 <AuPill>
                   {{targetAudience.label}}
                 </AuPill>
               </PillList>
             </td>
             <td>
-              <PillList @list={{await publicService.thematicAreasOrderedOnLabel}} as |thematicArea|>
+              <PillList
+                @list={{await publicService.thematicAreasOrderedOnLabel}}
+                as |thematicArea|
+              >
                 <AuPill>
                   {{thematicArea.label}}
                 </AuPill>
               </PillList>
             </td>
             <td>
-              <PillList @list={{await publicService.publicationMediaOrderedOnLabel}} as |publicationMedium|>
+              <PillList
+                @list={{await publicService.publicationMediaOrderedOnLabel}}
+                as |publicationMedium|
+              >
                 <AuPill>
                   {{publicationMedium.label}}
                 </AuPill>
@@ -277,8 +348,8 @@
                 @icon="info-circle"
                 @skin="info"
                 @size="small"
-                class="au-u-margin-bottom-none">
-              </AuAlert>
+                class="au-u-margin-bottom-none"
+              />
             </td>
           </tr>
         {{/if}}

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -38,12 +38,14 @@
         >
           Feedback beschikbaar
         </AuCheckbox>
-        <AuCheckbox
-          @checked={{this.isNotification}}
-          @onChange={{this.handleNotificationFilterChange}}
-        >
-          Notificaties
-        </AuCheckbox>
+        {{#if this.notificationService.isNotificationsEnabled}}
+          <AuCheckbox
+            @checked={{this.isNotification}}
+            @onChange={{this.handleNotificationFilterChange}}
+          >
+            Notificaties
+          </AuCheckbox>
+        {{/if}}
         {{#if
           (and
             (is-feature-enabled "fusies")
@@ -194,9 +196,11 @@
     >
       <Table.content as |Content|>
         <Content.header>
-          <th>
-            <AuIcon @icon={{this.AlarmIcon}} />
-          </th>
+          {{#if this.notificationService.isNotificationsEnabled}}
+            <th>
+              <AuIcon @icon={{this.AlarmIcon}} />
+            </th>
+          {{/if}}
           <th>
             Productnaam
           </th>
@@ -249,12 +253,14 @@
           </tr>
         {{else if this.hasResults}}
           <Content.body as |publicService|>
-            <td>
-              <AuCheckbox
-                @checked={{get this.notificationInstances publicService.id}}
-                @onChange={{fn this.handleNotificationChange publicService}}
-              />
-            </td>
+            {{#if this.notificationService.isNotificationsEnabled}}
+              <td>
+                <AuCheckbox
+                  @checked={{get this.notificationInstances publicService.id}}
+                  @onChange={{fn this.handleNotificationChange publicService}}
+                />
+              </td>
+            {{/if}}
             <td>
               {{! template-lint-disable no-triple-curlies~}}
               <AuLink

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -197,22 +197,12 @@
       <Table.content as |Content|>
         <Content.header>
           {{#if this.notificationService.isNotificationsEnabled}}
-            <th>
-              {{! template-lint-disable no-inline-styles }}
-              <AuButton
-                @skin="naked"
-                style="padding: 0"
-                {{on "click" this.subscribeAllInstances}}
+            <th class="au-u-padding-left-small">
+              <AuCheckbox
+                @checked={{this.allVisibleInstancesSubscribed}}
+                @onChange={{this.subscribeAllInstances}}
               >
-                <AuIcon
-                  @size="large"
-                  @icon={{if
-                    this.allVisibleInstancesSubscribed
-                    "checkbox-checked"
-                    "checkbox-unchecked"
-                  }}
-                />
-              </AuButton>
+              </AuCheckbox>
               <AuIcon @size="large" @icon={{this.AlarmIcon}} />
             </th>
           {{/if}}

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -208,8 +208,8 @@
                   @size="large"
                   @icon={{if
                     this.allVisibleInstancesSubscribed
-                    "checkbox-indeterminate"
                     "checkbox-checked"
+                    "checkbox-unchecked"
                   }}
                 />
               </AuButton>

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -40,7 +40,7 @@
         </AuCheckbox>
         {{#if this.notificationService.isNotificationsEnabled}}
           <AuCheckbox
-            @checked={{this.isNotification}}
+            @checked={{this.isNotificationEnabled}}
             @onChange={{this.handleNotificationFilterChange}}
           >
             Notificaties

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -198,7 +198,22 @@
         <Content.header>
           {{#if this.notificationService.isNotificationsEnabled}}
             <th>
-              <AuIcon @icon={{this.AlarmIcon}} />
+              {{! template-lint-disable no-inline-styles }}
+              <AuButton
+                @skin="naked"
+                style="padding: 0"
+                {{on "click" this.subscribeAllInstances}}
+              >
+                <AuIcon
+                  @size="large"
+                  @icon={{if
+                    this.allVisibleInstancesSubscribed
+                    "checkbox-indeterminate"
+                    "checkbox-checked"
+                  }}
+                />
+              </AuButton>
+              <AuIcon @size="large" @icon={{this.AlarmIcon}} />
             </th>
           {{/if}}
           <th>

--- a/app/utils/public-service-query.js
+++ b/app/utils/public-service-query.js
@@ -1,0 +1,61 @@
+export function buildPublicServiceFilters(params, currentSession) {
+  const query = {
+    'filter[created-by][:uri:]': currentSession.group.uri,
+  };
+
+  if (params.search) {
+    query['filter'] = params.search.trim();
+  }
+
+  if (params.isReviewRequiredFilterEnabled) {
+    query['filter[:has:review-status]'] = true;
+  }
+
+  if (params.needsConversionFromFormalToInformalFilterEnabled) {
+    query['filter[needs-conversion-from-formal-to-informal]'] = true;
+  }
+
+  if (params.isYourEurope) {
+    query['filter[publication-media][:uri:]'] =
+      'https://productencatalogus.data.vlaanderen.be/id/concept/PublicatieKanaal/YourEurope';
+  }
+
+  if (params.isFeedbackAvailable) {
+    query['filter[feedback-available]'] = true;
+  }
+
+  if (params.isNotificationEnabled) {
+    query['filter[notification-preferences][gebruiker][:id:]'] =
+      currentSession.user.id;
+  }
+
+  if (params.forMunicipalityMerger) {
+    query['filter[for-municipality-merger]'] = true;
+  }
+
+  if (params.statusIds?.length > 0) {
+    query['filter[status][:id:]'] = params.statusIds.join(',');
+  }
+
+  if (params.producttypesIds?.length > 0) {
+    query['filter[type][:id:]'] = params.producttypesIds.join(',');
+  }
+
+  if (params.doelgroepenIds?.length > 0) {
+    query['filter[target-audiences][:id:]'] = params.doelgroepenIds.join(',');
+  }
+
+  if (params.themaIds?.length > 0) {
+    query['filter[thematic-areas][:id:]'] = params.themaIds.join(',');
+  }
+
+  if (params.creatorIds?.length > 0) {
+    query['filter[creator][:id:]'] = params.creatorIds.join(',');
+  }
+
+  if (params.lastModifierIds?.length > 0) {
+    query['filter[last-modifier][:id:]'] = params.lastModifierIds.join(',');
+  }
+
+  return query;
+}


### PR DESCRIPTION
## ID

LPDC-1668

## Description

Add the notifications integration:
- filtering
- notifications popup
- subscribing / unsubscribing for instances

TODO:

- [x] add the 3rd screen for the popup that informs the user to select instances
- ~~auto activate notifications when user edits/saves/creates an instance (if notifications are on)~~
- use codelist for the frequencies (adhoc/weekly/monthly/bi-annual) https://github.com/lblod/frontend-lpdc/pull/55/changes#diff-538dcd15951ce0af6dfe75123b9dffad7d7700ea178b3931809f4f04ea6b3cedR55-R57
-> todo after backend

## Setup

Setup lpdc backend with https://github.com/lblod/app-lpdc-digitaal-loket/pull/105/ using TEST data, the [dev migration](https://github.com/lblod/app-lpdc-digitaal-loket/pull/105/changes#diff-b65b403db3eb097629b93a53a25cf966a5af05e16b0e1ded8ca00b9eaac8eede) creates a mock notificationPreference for gemeente leuven that should have the popup filled in already
