### PR TITLE
Update `ember-rdfa-editor` to version `13.4.0`

### DIFF
--- a/app/components/rdf-form-fields/rich-text-editor.js
+++ b/app/components/rdf-form-fields/rich-text-editor.js
@@ -49,6 +49,36 @@ import { modifier } from 'ember-modifier';
 import { NamedNode } from 'rdflib';
 
 export const linkParser = defaultLinkParser({ defaultCountryCode: 'BE' });
+
+// Custom regex used by the link prosemirror input-rule.
+// The input-rule will trigger when the regex is matched.
+// Compared to the default regex defined in the editor package, this regex also triggers when punctuation marks are entered after a link.
+const LINK_INPUT_RULE_REGEX = new RegExp(
+  String.raw`
+  (^|\s)
+  (
+    (?: ${/* parse email */ ''}
+      (?:mailto:)? ${/* optional mailto: protocol */ ''}
+      [A-Za-z0-9._%+-]+ ${/* local-part */ ''}
+      @
+      [A-Za-z0-9.-]+ ${/* domain */ ''}
+      \.
+      [A-Za-z]{2,} ${/* extension */ ''}
+    )
+    |
+    (?: ${/* parse weblinks */ ''}
+      (?:https?:\/\/)? ${/* optional http(s): protocol */ ''}
+      (?:www\.)? ${/* optional www */ ''}
+      [A-Za-z0-9.-]+ ${/* domain */ ''}
+      \.
+      [A-Za-z]{2,} ${/* extension */ ''}
+    )
+  )
+  ([.;:,]?[ \n])$ ${/* optional punctuation mark + single space or newline/enter after url/email */ ''}
+  `
+    .replace(/^\s+|\s+$/gm, '') // remove white space before and at the end of lines (trimming)
+    .replace(/\n/g, ''), // remove newlines
+);
 export default class RdfFormFieldsRichTextEditorComponent extends SimpleInputFieldComponent {
   @tracked editorController;
   inputId = 'richtext-' + guidFor(this);
@@ -113,7 +143,11 @@ export default class RdfFormFieldsRichTextEditorComponent extends SimpleInputFie
       rules: [
         bullet_list_input_rule(this.schema.nodes.bullet_list),
         ordered_list_input_rule(this.schema.nodes.ordered_list),
-        link_input_rule({ nodeType: this.schema.nodes.link, linkParser }),
+        link_input_rule({
+          nodeType: this.schema.nodes.link,
+          linkParser,
+          regex: LINK_INPUT_RULE_REGEX,
+        }),
       ],
     }),
   ];

--- a/app/components/rdf-form-fields/rich-text-editor.js
+++ b/app/components/rdf-form-fields/rich-text-editor.js
@@ -122,6 +122,7 @@ export default class RdfFormFieldsRichTextEditorComponent extends SimpleInputFie
     return {
       interactive: true,
       linkParser,
+      target: '_blank',
     };
   }
 
@@ -202,6 +203,7 @@ function stripNbspEntities(htmlContent) {
 
 // Modifier that forces the link children of a certain element to open in a new tab, regardless of the _blank attribute on the elements.
 // We use this to always open user provided links in a new tab.
+// Needed for links created in a older version of the editor.
 const forceOpenLinksInNewTab = modifier(
   function forceOpenLinksInNewTab(contentElement) {
     const links = contentElement.querySelectorAll('a');

--- a/app/components/rdf-form-fields/rich-text-editor.js
+++ b/app/components/rdf-form-fields/rich-text-editor.js
@@ -237,7 +237,7 @@ function stripNbspEntities(htmlContent) {
 
 // Modifier that forces the link children of a certain element to open in a new tab, regardless of the _blank attribute on the elements.
 // We use this to always open user provided links in a new tab.
-// Needed for links created in a older version of the editor.
+// Needed for links created in a older version of the editor; or for links included in external html.
 const forceOpenLinksInNewTab = modifier(
   function forceOpenLinksInNewTab(contentElement) {
     const links = contentElement.querySelectorAll('a');

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@glimmer/tracking": "^1.1.2",
         "@lblod/ember-acmidm-login": "^2.3.0",
         "@lblod/ember-mock-login": "^0.14.0",
-        "@lblod/ember-rdfa-editor": "^13.5.0",
+        "@lblod/ember-rdfa-editor": "^13.14.0",
         "@lblod/ember-submission-form-fields": "^3.3.0",
         "@lblod/submission-form-helpers": "^3.1.0",
         "@sentry/ember": "^7.54.0",
@@ -6668,9 +6668,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-13.5.0.tgz",
-      "integrity": "sha512-AoykeFaHlFZwEgwvQW8dYwiW4pGOrLvONsN8K+nOuNpNp5QkXkzkBdKu/ePamoSrzyRnVmLer/0efIz27Q2sYg==",
+      "version": "13.14.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-13.14.0.tgz",
+      "integrity": "sha512-cC8wsSGSG0/e8skH5Z4eUQ4l25tjinNktphXx6hRCl7hKfrfU1VRZvIFWuxu3090ESZerv+nfZY2I5zuNNNWUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6683,16 +6683,15 @@
         "@ember/optional-features": "^2.3.0",
         "@ember/render-modifiers": "^3.0.0",
         "@embroider/addon-shim": "^1.10.2",
-        "@embroider/macros": "^1.19.6",
         "@floating-ui/dom": "^1.7.4",
         "@glint/tsserver-plugin": "2.1.0",
-        "@lblod/marawa": "0.8.0-beta.6",
-        "@rdfjs/types": "^1.1.2",
+        "@rdfjs/types": "^2.0.1",
         "@say-editor/prosemirror-invisibles": "^0.1.1",
         "@say-editor/prosemirror-tables": "^0.3.0",
         "@types/react": "19.1.13",
         "codemirror": "^6.0.2",
         "common-tags": "^1.8.2",
+        "date-fns": "^2.30.0",
         "debug": "^4.4.3",
         "decorator-transforms": "^2.3.1",
         "dompurify": "3.2.4",
@@ -6701,7 +6700,9 @@
         "ember-focus-trap": "^1.1.1",
         "ember-headless-form": "^1.1.1",
         "ember-headless-form-yup": "^1.0.0",
+        "ember-lifeline": "^7.0.0",
         "ember-modifier": "^4.2.2",
+        "ember-resources": "^7.0.7",
         "ember-template-imports": "^4.4.0",
         "ember-truth-helpers": "^5.0.0",
         "ember-velcro": "^2.2.0",
@@ -6716,13 +6717,13 @@
         "prosemirror-dropcursor": "^1.8.2",
         "prosemirror-inputrules": "^1.5.1",
         "prosemirror-keymap": "^1.2.3",
-        "prosemirror-model": "^1.25.4",
+        "prosemirror-model": "^1.25.9",
         "prosemirror-schema-basic": "^1.2.4",
         "prosemirror-schema-list": "^1.5.1",
         "prosemirror-state": "^1.4.4",
         "prosemirror-transform": "^1.11.0",
         "prosemirror-view": "^1.41.5",
-        "rdf-data-factory": "^1.1.3",
+        "rdf-data-factory": "^2.0.2",
         "reactiveweb": "^1.9.1",
         "relative-to-absolute-iri": "^1.0.7",
         "tracked-toolbox": "^2.2.0",
@@ -6732,7 +6733,7 @@
         "yup": "^1.7.1"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^3.11.0",
+        "@appuniversum/ember-appuniversum": "^3.11.0 || ^4.2.1",
         "@ember/test-helpers": "^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0",
         "@glimmer/component": "^1.1.2 || ^2.0.0",
         "@glimmer/tracking": "^1.1.2",
@@ -6749,16 +6750,6 @@
         "@glint/template": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor/node_modules/@rdfjs/types": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/n3": {
@@ -6853,17 +6844,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@lblod/marawa": {
-      "version": "0.8.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@lblod/marawa/-/marawa-0.8.0-beta.6.tgz",
-      "integrity": "sha512-BW3yCpeQlk9EPnQAEQnM9uViA8RC5DkuoiaPJzbuhMcLvKHfI4cjc6dTg9i8qAijbL/xObmQ/Aexko2Xcj9ktw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.2.0",
-        "@rdfjs/dataset": "^1.1.0"
       }
     },
     "node_modules/@lblod/submission-form-helpers": {
@@ -7674,32 +7654,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@rdfjs/data-model": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
-      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": ">=1.0.1"
-      },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/@rdfjs/dataset": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.2.0"
-      },
-      "bin": {
-        "rdfjs-dataset-test": "bin/test.js"
       }
     },
     "node_modules/@rdfjs/types": {
@@ -24205,6 +24159,27 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-lifeline": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ember-lifeline/-/ember-lifeline-7.1.0.tgz",
+      "integrity": "sha512-hd3r0jwZLgXNn3l2YSX6wVnD1KD5h+WUG6P/xo4rJXFboy7nOwix38fZt9SbuO66QVZSkdqMeUqW6Z/NPWa9kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.6.0"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
+      },
+      "peerDependencies": {
+        "@ember/test-helpers": ">= 1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ember/test-helpers": {
+          "optional": true
+        }
       }
     },
     "node_modules/ember-load-initializers": {
@@ -44637,9 +44612,9 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
-      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "version": "1.25.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.9.tgz",
+      "integrity": "sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -45069,23 +45044,17 @@
       }
     },
     "node_modules/rdf-data-factory": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rdfjs/types": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-data-factory/node_modules/@rdfjs/types": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/rdflib": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@lblod/ember-acmidm-login": "^2.3.0",
     "@lblod/ember-mock-login": "^0.14.0",
-    "@lblod/ember-rdfa-editor": "^13.5.0",
+    "@lblod/ember-rdfa-editor": "^13.14.0",
     "@lblod/ember-submission-form-fields": "^3.3.0",
     "@lblod/submission-form-helpers": "^3.1.0",
     "@sentry/ember": "^7.54.0",


### PR DESCRIPTION
### Overview
This PR updates the `ember-rdfa-editor` dependency to version `13.4.0`.
Alongside this update, this PR also includes:
- Improved UX for detecting plain text links: links are now also converted to a link node with the following trigger characters:
  - `Enter`
  - `.|;|:|,` + `Enter|<space>`
- The read-only/exported versions of links are now opened in a new tab by default (only for new/edited links)


##### connected issues and PRs:
[LPDC-1479](https://binnenland.atlassian.net/browse/LPDC-1479?atlOrigin=eyJpIjoiYWZmNTk5NzkyZWY1NDI1NTkyOGVjNTYxYzVkNjliMzgiLCJwIjoiaiJ9)
[LPDC-1636](https://binnenland.atlassian.net/browse/LPDC-1636?atlOrigin=eyJpIjoiYjlmZDU3M2IwYTc1NDdmN2EyYjJkZmM0YmMyZDFlZjIiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the application
- Open a product/service
- In any of the editor text fields: type a plain text + a triggering punctuation character/`Enter`. The link should be converted to an interactive link node.
- Save the product
- Open a readonly version of the product
- The newly inserted link should open in a new tab by default (even with the `forceOpenLinksInNewTab` modifier disabled; see https://github.com/lblod/frontend-lpdc/blob/d370d7b600e60609338827a8a65be71bfda5da02/app/components/rdf-form-fields/rich-text-editor.js#L241)

### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Tested on Firefox and Chrome-based browsers
- [x] npm lint
