### PR TITLE
[LPDC-1706]: add (un)subscribe all button for notifications

### DIFF
--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { serviceNeedsReview } from 'frontend-lpdc/models/public-service';
 import NotificationModal from 'frontend-lpdc/components/notification-modal';
+import { buildPublicServiceFilters } from 'frontend-lpdc/utils/public-service-query';
 import { inject as service } from '@ember/service';
 import AlarmIcon from 'frontend-lpdc/components/icons/alarm';
 
@@ -318,64 +319,10 @@ export default class PublicServicesIndexController extends Controller {
   @action
   async subscribeAllInstances() {
     const query = {
+      ...buildPublicServiceFilters(this, this.currentSession),
       'fields[public-services]': 'id',
-      'filter[created-by][:uri:]': this.currentSession.group.uri,
       'page[size]': 9999,
     };
-
-    if (this.search) {
-      query['filter'] = this.search.trim();
-    }
-
-    if (this.isReviewRequiredFilterEnabled) {
-      query['filter[:has:review-status]'] = true;
-    }
-
-    if (this.needsConversionFromFormalToInformalFilterEnabled) {
-      query['filter[needs-conversion-from-formal-to-informal]'] = true;
-    }
-
-    if (this.isYourEurope) {
-      query['filter[publication-media][:uri:]'] =
-        'https://productencatalogus.data.vlaanderen.be/id/concept/PublicatieKanaal/YourEurope';
-    }
-
-    if (this.isFeedbackAvailable) {
-      query['filter[feedback-available]'] = true;
-    }
-
-    if (this.isNotificationEnabled) {
-      query['filter[notification-preferences][gebruiker][:id:]'] =
-        this.currentSession.user.id;
-    }
-
-    if (this.forMunicipalityMerger) {
-      query['filter[for-municipality-merger]'] = true;
-    }
-
-    if (this.statusIds?.length > 0) {
-      query['filter[status][:id:]'] = this.statusIds.join(',');
-    }
-
-    if (this.producttypesIds?.length > 0) {
-      query['filter[type][:id:]'] = this.producttypesIds.join(',');
-    }
-
-    if (this.doelgroepenIds?.length > 0) {
-      query['filter[target-audiences][:id:]'] = this.doelgroepenIds.join(',');
-    }
-
-    if (this.themaIds?.length > 0) {
-      query['filter[thematic-areas][:id:]'] = this.themaIds.join(',');
-    }
-
-    if (this.creatorIds?.length > 0) {
-      query['filter[creator][:id:]'] = this.creatorIds.join(',');
-    }
-
-    if (this.lastModifierIds?.length > 0) {
-      query['filter[last-modifier][:id:]'] = this.lastModifierIds.join(',');
-    }
 
     const allServices = await this.store.query('public-service', query);
 

--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -28,7 +28,7 @@ export default class PublicServicesIndexController extends Controller {
   @service('notification') notificationService;
   @service currentSession;
   @service store;
-  @tracked notificationInstances = [];
+  @tracked notificationInstances = {};
   AlarmIcon = AlarmIcon;
 
   get statuses() {
@@ -266,6 +266,11 @@ export default class PublicServicesIndexController extends Controller {
 
   @action
   async handleNotificationChange(publicService, isChecked) {
+    this.notificationInstances = {
+      ...this.notificationInstances,
+      [publicService.id]: isChecked,
+    };
+
     if (isChecked) {
       await this.notificationService.addInstance(publicService);
     } else {
@@ -299,6 +304,99 @@ export default class PublicServicesIndexController extends Controller {
         await this.loadNotificationInstances();
       },
     });
+  }
+
+  get allVisibleInstancesSubscribed() {
+    return (
+      this.publicServices.length > 0 &&
+      this.publicServices.every(
+        (instance) => this.notificationInstances[instance.id],
+      )
+    );
+  }
+
+  @action
+  async subscribeAllInstances() {
+    const query = {
+      'fields[public-services]': 'id',
+      'filter[created-by][:uri:]': this.currentSession.group.uri,
+      'page[size]': 9999,
+    };
+
+    if (this.search) {
+      query['filter'] = this.search.trim();
+    }
+
+    if (this.isReviewRequiredFilterEnabled) {
+      query['filter[:has:review-status]'] = true;
+    }
+
+    if (this.needsConversionFromFormalToInformalFilterEnabled) {
+      query['filter[needs-conversion-from-formal-to-informal]'] = true;
+    }
+
+    if (this.isYourEurope) {
+      query['filter[publication-media][:uri:]'] =
+        'https://productencatalogus.data.vlaanderen.be/id/concept/PublicatieKanaal/YourEurope';
+    }
+
+    if (this.isFeedbackAvailable) {
+      query['filter[feedback-available]'] = true;
+    }
+
+    if (this.isNotificationEnabled) {
+      query['filter[notification-preferences][gebruiker][:id:]'] =
+        this.currentSession.user.id;
+    }
+
+    if (this.forMunicipalityMerger) {
+      query['filter[for-municipality-merger]'] = true;
+    }
+
+    if (this.statusIds?.length > 0) {
+      query['filter[status][:id:]'] = this.statusIds.join(',');
+    }
+
+    if (this.producttypesIds?.length > 0) {
+      query['filter[type][:id:]'] = this.producttypesIds.join(',');
+    }
+
+    if (this.doelgroepenIds?.length > 0) {
+      query['filter[target-audiences][:id:]'] = this.doelgroepenIds.join(',');
+    }
+
+    if (this.themaIds?.length > 0) {
+      query['filter[thematic-areas][:id:]'] = this.themaIds.join(',');
+    }
+
+    if (this.creatorIds?.length > 0) {
+      query['filter[creator][:id:]'] = this.creatorIds.join(',');
+    }
+
+    if (this.lastModifierIds?.length > 0) {
+      query['filter[last-modifier][:id:]'] = this.lastModifierIds.join(',');
+    }
+
+    const allServices = await this.store.query('public-service', query);
+
+    // if everything (visible) was subscribed we then unsubscribe
+    if (this.allVisibleInstancesSubscribed) {
+      const updated = { ...this.notificationInstances };
+      for (const instance of this.publicServices) {
+        updated[instance.id] = false;
+      }
+      this.notificationInstances = updated;
+
+      await this.notificationService.removeInstances(allServices);
+    } else {
+      const updated = { ...this.notificationInstances };
+      for (const instance of this.publicServices) {
+        updated[instance.id] = true;
+      }
+      this.notificationInstances = updated;
+
+      await this.notificationService.addInstances(allServices);
+    }
   }
 }
 

--- a/app/routes/public-services/index.js
+++ b/app/routes/public-services/index.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 import SelectUOrJeModal from 'frontend-lpdc/components/select-u-or-je-modal';
 import NotificationModal from 'frontend-lpdc/components/notification-modal';
+import { buildPublicServiceFilters } from 'frontend-lpdc/utils/public-service-query';
 
 export default class PublicServicesIndexRoute extends Route {
   @service store;
@@ -113,92 +114,20 @@ export default class PublicServicesIndexRoute extends Route {
     controller.loadNotificationInstances();
   }
 
-  loadPublicServicesTask = restartableTask(
-    async ({
-      search,
-      page,
-      sort,
-      isReviewRequiredFilterEnabled,
-      needsConversionFromFormalToInformalFilterEnabled,
-      isYourEurope,
-      forMunicipalityMerger,
-      isFeedbackAvailable,
-      isNotificationEnabled,
-      doelgroepenIds,
-      producttypesIds,
-      themaIds,
-      creatorIds,
-      lastModifierIds,
-      statusIds,
-    }) => {
-      const query = {
-        'filter[created-by][:uri:]': this.currentSession.group.uri,
-        'page[number]': page,
-        'fields[public-services]':
-          'name,product-id,type,target-audiences,thematic-areas,publication-media,date-created,date-modified,status,needs-conversion-from-formal-to-informal,review-status,for-municipality-merger,feedback-available',
-        include:
-          'type,target-audiences,thematic-areas,publication-media,status,review-status,creator,last-modifier',
-      };
+  loadPublicServicesTask = restartableTask(async (params) => {
+    const query = {
+      ...buildPublicServiceFilters(params, this.currentSession),
+      'page[number]': params.page,
+      'fields[public-services]':
+        'name,product-id,type,target-audiences,thematic-areas,publication-media,date-created,date-modified,status,needs-conversion-from-formal-to-informal,review-status,for-municipality-merger,feedback-available',
+      include:
+        'type,target-audiences,thematic-areas,publication-media,status,review-status,creator,last-modifier',
+    };
 
-      if (search) {
-        query['filter'] = search.trim();
-      }
+    if (params.sort) {
+      query.sort = params.sort;
+    }
 
-      if (sort) {
-        query.sort = sort;
-      }
-
-      if (isReviewRequiredFilterEnabled) {
-        query['filter[:has:review-status]'] = true;
-      }
-
-      if (needsConversionFromFormalToInformalFilterEnabled) {
-        query['filter[needs-conversion-from-formal-to-informal]'] = true;
-      }
-
-      if (isYourEurope) {
-        query['filter[publication-media][:uri:]'] =
-          'https://productencatalogus.data.vlaanderen.be/id/concept/PublicatieKanaal/YourEurope';
-      }
-
-      if (isFeedbackAvailable) {
-        query['filter[feedback-available]'] = true;
-      }
-
-      if (isNotificationEnabled) {
-        query['filter[notification-preferences][gebruiker][:id:]'] =
-          this.currentSession.user.id;
-      }
-
-      if (forMunicipalityMerger) {
-        query['filter[for-municipality-merger]'] = true;
-      }
-
-      if (statusIds?.length > 0) {
-        query['filter[status][:id:]'] = statusIds.join(',');
-      }
-
-      if (producttypesIds?.length > 0) {
-        query['filter[type][:id:]'] = producttypesIds.join(',');
-      }
-
-      if (doelgroepenIds?.length > 0) {
-        query['filter[target-audiences][:id:]'] = doelgroepenIds.join(',');
-      }
-
-      if (themaIds?.length > 0) {
-        query['filter[thematic-areas][:id:]'] = themaIds.join(',');
-      }
-
-      if (creatorIds?.length > 0) {
-        query['filter[creator][:id:]'] = creatorIds.join(',');
-      }
-
-      if (lastModifierIds?.length > 0) {
-        query['filter[last-modifier][:id:]'] = lastModifierIds.join(',');
-      }
-
-      return await this.store.query('public-service', query);
-    },
-  );
+    return await this.store.query('public-service', query);
+  });
 }

--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -32,6 +32,7 @@ export default class NotificationService extends Service {
 
     const preferences = await this.store.query('notification-preference', {
       'filter[gebruiker][:id:]': this.currentSession.user.id,
+      include: 'gebruiker,instances',
     });
     this.notificationPreference = preferences[0];
     return this.notificationPreference;
@@ -53,11 +54,26 @@ export default class NotificationService extends Service {
     await preference.save();
   }
 
+  async addInstances(newInstances) {
+    const preference = await this.getNotificationPreference();
+    const instances = await preference.instances;
+    preference.instances = [...new Set([...instances, ...newInstances])];
+    await preference.save();
+  }
+
   async removeInstance(instance) {
     const preference = await this.getNotificationPreference();
     const instances = await preference.instances;
 
     preference.instances = instances.filter((i) => i !== instance);
+    await preference.save();
+  }
+
+  async removeInstances(instancesToRemove) {
+    const preference = await this.getNotificationPreference();
+    const instances = await preference.instances;
+    const removeIds = new Set(instancesToRemove.map((i) => i.id));
+    preference.instances = instances.filter((i) => !removeIds.has(i.id));
     await preference.save();
   }
 

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -197,22 +197,12 @@
       <Table.content as |Content|>
         <Content.header>
           {{#if this.notificationService.isNotificationsEnabled}}
-            <th>
-              {{! template-lint-disable no-inline-styles }}
-              <AuButton
-                @skin="naked"
-                style="padding: 0"
-                {{on "click" this.subscribeAllInstances}}
+            <th class="au-u-padding-left-small">
+              <AuCheckbox
+                @checked={{this.allVisibleInstancesSubscribed}}
+                @onChange={{this.subscribeAllInstances}}
               >
-                <AuIcon
-                  @size="large"
-                  @icon={{if
-                    this.allVisibleInstancesSubscribed
-                    "checkbox-checked"
-                    "checkbox-unchecked"
-                  }}
-                />
-              </AuButton>
+              </AuCheckbox>
               <AuIcon @size="large" @icon={{this.AlarmIcon}} />
             </th>
           {{/if}}

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -208,8 +208,8 @@
                   @size="large"
                   @icon={{if
                     this.allVisibleInstancesSubscribed
-                    "checkbox-indeterminate"
                     "checkbox-checked"
+                    "checkbox-unchecked"
                   }}
                 />
               </AuButton>

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -198,7 +198,22 @@
         <Content.header>
           {{#if this.notificationService.isNotificationsEnabled}}
             <th>
-              <AuIcon @icon={{this.AlarmIcon}} />
+              {{! template-lint-disable no-inline-styles }}
+              <AuButton
+                @skin="naked"
+                style="padding: 0"
+                {{on "click" this.subscribeAllInstances}}
+              >
+                <AuIcon
+                  @size="large"
+                  @icon={{if
+                    this.allVisibleInstancesSubscribed
+                    "checkbox-indeterminate"
+                    "checkbox-checked"
+                  }}
+                />
+              </AuButton>
+              <AuIcon @size="large" @icon={{this.AlarmIcon}} />
             </th>
           {{/if}}
           <th>

--- a/app/utils/public-service-query.js
+++ b/app/utils/public-service-query.js
@@ -1,0 +1,61 @@
+export function buildPublicServiceFilters(params, currentSession) {
+  const query = {
+    'filter[created-by][:uri:]': currentSession.group.uri,
+  };
+
+  if (params.search) {
+    query['filter'] = params.search.trim();
+  }
+
+  if (params.isReviewRequiredFilterEnabled) {
+    query['filter[:has:review-status]'] = true;
+  }
+
+  if (params.needsConversionFromFormalToInformalFilterEnabled) {
+    query['filter[needs-conversion-from-formal-to-informal]'] = true;
+  }
+
+  if (params.isYourEurope) {
+    query['filter[publication-media][:uri:]'] =
+      'https://productencatalogus.data.vlaanderen.be/id/concept/PublicatieKanaal/YourEurope';
+  }
+
+  if (params.isFeedbackAvailable) {
+    query['filter[feedback-available]'] = true;
+  }
+
+  if (params.isNotificationEnabled) {
+    query['filter[notification-preferences][gebruiker][:id:]'] =
+      currentSession.user.id;
+  }
+
+  if (params.forMunicipalityMerger) {
+    query['filter[for-municipality-merger]'] = true;
+  }
+
+  if (params.statusIds?.length > 0) {
+    query['filter[status][:id:]'] = params.statusIds.join(',');
+  }
+
+  if (params.producttypesIds?.length > 0) {
+    query['filter[type][:id:]'] = params.producttypesIds.join(',');
+  }
+
+  if (params.doelgroepenIds?.length > 0) {
+    query['filter[target-audiences][:id:]'] = params.doelgroepenIds.join(',');
+  }
+
+  if (params.themaIds?.length > 0) {
+    query['filter[thematic-areas][:id:]'] = params.themaIds.join(',');
+  }
+
+  if (params.creatorIds?.length > 0) {
+    query['filter[creator][:id:]'] = params.creatorIds.join(',');
+  }
+
+  if (params.lastModifierIds?.length > 0) {
+    query['filter[last-modifier][:id:]'] = params.lastModifierIds.join(',');
+  }
+
+  return query;
+}


### PR DESCRIPTION
## ID

LPDC-1706

## Description

Added (un)subscribe all button for the notifications, as requested by Geertrui it will select all instances with current filters and not only the current 20 instances visible.
-> Had to extract the filtering query into a shared util to avoid duplicate code and maintaining both places

## Setup and testing

Avoid subscribing/unsubscribing while proxying to TEST with existing bestuurseenheden as we are in the process of testing the whole notification flow. Use a new organization that doesn't have notifications enabled already. (or rsync the data folder locally)

Enable the notifications feature (bell icon) and try the checkbox in the table header. Clicking again should unsubscribe. 